### PR TITLE
ci: independent UI image tag and push to docker on master build success

### DIFF
--- a/.build_tags
+++ b/.build_tags
@@ -1,0 +1,2 @@
+CLI_VERSION=master
+CORE_VERSION=v0.9.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,12 @@ jobs:
       node_js:
       services:
         - docker
-#      before_install:
-#        - "echo -e \"machine github.com\n  login ${GITHUB_USER_TOKEN}\" >> ~/.netrc"
-#        - docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}" ;
       install: skip
-      script: docker build -f tools/docker/dev.Dockerfile -t flogo/flogo-web:master  .
-      after_script:
-        - "[ -f \"${HOME}/.netrc\" ] && rm -f ${HOME}/.netrc"
-#      after_success:
-#        - "if [ \"${TRAVIS_BRANCH}\" == \"master\" ]; then
-#          docker push flogo/flogo-web:master ;
-#          fi"
+      script: RELEASE_VERSION=latest ./make-web.sh
+      after_success: |
+        if [ "${TRAVIS_BRANCH}" == "master" ]; then
+          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          docker tag flogo/flogo-web:latest flogo/flogo-web:unstable
+          docker push flogo/flogo-web:unstable
+        fi
+

--- a/make-web.sh
+++ b/make-web.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 
+load_tags() {
+	while IFS='=' read -r key value || [ -n "$key" ]; do
+    eval "existing=\"\${$key}\""
+    if [ -z "$existing" ]; then
+      eval export "$key='${value}'";
+    fi
+	done < $1
+}
 
-readonly RELEASE_VERSION=${RELEASE_VERSION:-"v0.9.0-rc.2"}
+if [ -f ".build_tags" ]; then
+  load_tags ".build_tags"
+fi
 
-readonly CLI_VERSION="master"
-readonly CORE_VERSION=${RELEASE_VERSION:master}
+readonly RELEASE_VERSION=${RELEASE_VERSION:-latest}
+readonly CLI_VERSION=${CLI_VERSION:-master}
+readonly CORE_VERSION=${CORE_VERSION:-master}
 
 export BUILD_ARGS="--build-arg CLI_VERSION=${CLI_VERSION} --build-arg CORE_VERSION=${CORE_VERSION}"
 
+echo "RELEASE_VERSION=$RELEASE_VERSION | CLI_VERSION=$CLI_VERSION | CORE_VERSION=$CORE_VERSION"
 
-docker build ${BUILD_ARGS} --force-rm=true --rm=true -t flogo/flogo-web:${RELEASE_VERSION:-latest} -f tools/docker/Dockerfile .
+docker build ${BUILD_ARGS} --force-rm=true --rm=true -t flogo/flogo-web:${RELEASE_VERSION} -f tools/docker/Dockerfile .
 


### PR DESCRIPTION
- Allow to have a tag for Web UI different than the CLI and core versions
- Version CLI and core dependencies
- Push to dockerhub on build success. Pushing with tag `unstable`. Pushing it as private image for now.