### PR TITLE
Fix wrong path to default-contrib-bundle file

### DIFF
--- a/apps/server/src/config/app-config.js
+++ b/apps/server/src/config/app-config.js
@@ -62,7 +62,8 @@ const config = {
   defaultEngine: {
     path: defaultEngine,
     defaultContribBundle:
-      process.env.FLOGO_WEB_DEFAULT_PALETTE || 'default-contrib-bundle.json',
+      process.env.FLOGO_WEB_DEFAULT_PALETTE ||
+      path.join(rootPath, 'config', 'default-contrib-bundle.json'),
   },
   /* apps module config */
   // TODO: consolidate and cleanup

--- a/apps/server/src/modules/engine/registry.ts
+++ b/apps/server/src/modules/engine/registry.ts
@@ -70,11 +70,7 @@ async function createEngine(engine, defaultFlogoDescriptorPath, skipBundleInstal
     if (skipBundleInstall) {
       return true;
     }
-    const contribBundlePath = path.resolve(
-      'src',
-      'config',
-      config.defaultEngine.defaultContribBundle
-    );
+    const contribBundlePath = config.defaultEngine.defaultContribBundle;
     logger.info(`Will install contrib bundle at ${contribBundlePath}`);
     await installResourceTypes(engine, defaultResourceTypes);
     await engine.installContribBundle(contribBundlePath);


### PR DESCRIPTION
The path to the default-contrib-bundle is messed recently and no longer found while starting the server. 

This change now requires the environment variable `FLOGO_WEB_DEFAULT_PALETTE` to provide full path of the file instead a file (similar to `FLOGO_WEB_DEFAULT_DESCRIPTOR`)