### PR TITLE
[part of 1123] Implemented diagram module for streams to design the stream stages

### DIFF
--- a/apps/client/src/i18n/en.json
+++ b/apps/client/src/i18n/en.json
@@ -287,6 +287,7 @@
   "STREAMS": {
     "DESIGNER:ERROR-STREAM-NAME-EXISTS": "Stream with name \"{{value}}\" already exists, please choose another name.",
     "DESIGNER:ERROR-UPDATE-STREAM": "Update stream's {{value}} error",
-    "DESIGNER:SUCCESS-UPDATE-STREAM": "Stream's {{value}} successfully updated"
+    "DESIGNER:SUCCESS-UPDATE-STREAM": "Stream's {{value}} successfully updated",
+    "DESIGNER:CONFIRM-STAGE-DELETE": "Are you sure you want to delete this stage?"
   }
 }

--- a/libs/lib-client/core/src/interfaces/graph/graph.ts
+++ b/libs/lib-client/core/src/interfaces/graph/graph.ts
@@ -3,7 +3,9 @@ import { GraphNode } from './node';
 
 export type NodeDictionary = Dictionary<GraphNode>;
 
-export interface FlowGraph {
+export interface DiagramGraph {
   rootId: string;
   nodes: NodeDictionary;
 }
+
+export { DiagramGraph as FlowGraph };

--- a/libs/lib-client/core/src/interfaces/graph/graph.ts
+++ b/libs/lib-client/core/src/interfaces/graph/graph.ts
@@ -8,4 +8,8 @@ export interface DiagramGraph {
   nodes: NodeDictionary;
 }
 
+/**
+ * Exporting DiagramGraph as FlowGraph which is imported in plugins-flow-client.
+ * @deprecated
+ */
 export { DiagramGraph as FlowGraph };

--- a/libs/lib-client/core/src/interfaces/graph/index.ts
+++ b/libs/lib-client/core/src/interfaces/graph/index.ts
@@ -1,2 +1,2 @@
-export { FlowGraph, NodeDictionary as GraphNodeDictionary } from './graph';
+export { DiagramGraph, FlowGraph, NodeDictionary as GraphNodeDictionary } from './graph';
 export * from './node';

--- a/libs/plugins/stream-client/src/lib/core/effects/stream-save.effects.ts
+++ b/libs/plugins/stream-client/src/lib/core/effects/stream-save.effects.ts
@@ -5,7 +5,7 @@ import { switchMap, filter, map } from 'rxjs/operators';
 import { Action } from '@ngrx/store';
 
 import { StreamService } from '../stream.service';
-import { StreamSaveSuccess, StreamActionType } from '../state';
+import { StreamDiagramActions, StreamActionType } from '../state';
 
 @Injectable()
 export class StreamSaveEffects {
@@ -14,20 +14,33 @@ export class StreamSaveEffects {
     ofType(StreamActionType.ChangeName),
     switchMap(() => this.streamOps.saveStreamName()),
     filter(isSaved => isSaved),
-    map(() => new StreamSaveSuccess())
+    map(() => new StreamDiagramActions.StreamSaveSuccess())
   );
 
   @Effect()
   saveStream$: Observable<Action> = this.actions$.pipe(
-    ofType(StreamActionType.ChangeDescription),
+    ofType(StreamActionType.ChangeDescription, StreamActionType.DeleteStage),
     switchMap(action => this.saveStream(action)),
     filter(isSaved => isSaved),
-    map(() => new StreamSaveSuccess())
+    map(() => new StreamDiagramActions.StreamSaveSuccess())
+  );
+
+  @Effect()
+  deleteStage$: Observable<Action> = this.actions$.pipe(
+    ofType(StreamActionType.SelectRemoveStage),
+    switchMap((action: StreamDiagramActions.SelectRemoveStage) =>
+      this.showDeleteMessage(action.payload)
+    ),
+    map(removeItemId => new StreamDiagramActions.ConfirmDeleteStage(removeItemId))
   );
 
   constructor(private streamOps: StreamService, private actions$: Actions) {}
 
   private saveStream(action?: Action) {
     return this.streamOps.saveStream(action);
+  }
+
+  private showDeleteMessage(itemId) {
+    return this.streamOps.getDeleteStageConfirmation(itemId);
   }
 }

--- a/libs/plugins/stream-client/src/lib/core/models/generate-resource-from-state.ts
+++ b/libs/plugins/stream-client/src/lib/core/models/generate-resource-from-state.ts
@@ -10,22 +10,14 @@ import { createStagesFromGraph } from './graph-and-items';
 export function generateResourceFromState(state: FlogoStreamState): any {
   const metadata = normalizeMetadata(state.metadata);
   const stages = createStagesFromGraph(state.mainItems, state.mainGraph);
-  const streamResource = {
+  return {
     id: state.id,
     type: 'stream',
     name: state.name,
     description: state.description,
-  } as any;
-  if (metadata) {
-    streamResource.metadata = metadata;
-  }
-
-  if (stages) {
-    streamResource.data = {
-      stages,
-    };
-  }
-  return streamResource;
+    metadata: metadata || {},
+    data: stages ? { stages } : {},
+  };
 }
 
 function normalizeMetadata(source: Metadata): Metadata {

--- a/libs/plugins/stream-client/src/lib/core/models/graph-and-items/graph-creator.ts
+++ b/libs/plugins/stream-client/src/lib/core/models/graph-and-items/graph-creator.ts
@@ -1,11 +1,7 @@
-import {
-  FlowGraph as StreamGraph,
-  GraphNode,
-  NodeType,
-} from '@flogo-web/lib-client/core';
+import { DiagramGraph, GraphNode, NodeType } from '@flogo-web/lib-client/core';
 
 /* streams-plugin-todo: Add the streams backend interface */
-export function makeGraphNodes(stages: any[]): StreamGraph {
+export function makeGraphNodes(stages: any[]): DiagramGraph {
   const [rootStage] = stages;
   const nodes = stages.reduce((graphNodes, stage, index, allStages) => {
     const node = makeBasicNode(stage);

--- a/libs/plugins/stream-client/src/lib/core/models/graph-and-items/stage-creator.ts
+++ b/libs/plugins/stream-client/src/lib/core/models/graph-and-items/stage-creator.ts
@@ -1,6 +1,6 @@
 import { isEmpty } from 'lodash';
 
-import { Dictionary, FlowGraph as DiagramGraph } from '@flogo-web/lib-client/core';
+import { Dictionary, DiagramGraph } from '@flogo-web/lib-client/core';
 
 import { Item } from '../../interfaces';
 

--- a/libs/plugins/stream-client/src/lib/core/models/handler-type.ts
+++ b/libs/plugins/stream-client/src/lib/core/models/handler-type.ts
@@ -1,4 +1,0 @@
-export enum HandlerType {
-  Main = 'main',
-  Error = 'error',
-}

--- a/libs/plugins/stream-client/src/lib/core/models/selection.ts
+++ b/libs/plugins/stream-client/src/lib/core/models/selection.ts
@@ -1,5 +1,3 @@
-import { HandlerType } from './handler-type';
-
 export enum SelectionType {
   InsertTask = 'insertTask',
   Task = 'task',
@@ -11,13 +9,11 @@ export type CurrentSelection = TaskSelection | InsertTaskSelection | TriggerSele
 export interface TaskSelection {
   type: SelectionType.Task;
   taskId: string;
-  handlerType?: HandlerType;
 }
 
 export interface InsertTaskSelection {
   type: SelectionType.InsertTask;
   parentId: string;
-  handlerType: HandlerType;
 }
 
 export interface TriggerSelection {

--- a/libs/plugins/stream-client/src/lib/core/models/stream/selection.ts
+++ b/libs/plugins/stream-client/src/lib/core/models/stream/selection.ts
@@ -1,4 +1,24 @@
-import { CurrentSelection, SelectionType, TriggerSelection } from '../selection';
+import {
+  CurrentSelection,
+  SelectionType,
+  TriggerSelection,
+  InsertTaskSelection,
+  TaskSelection,
+} from '../selection';
+
+export function makeInsertSelection(parentId: string): InsertTaskSelection {
+  return {
+    type: SelectionType.InsertTask,
+    parentId,
+  };
+}
+
+export function makeStageSelection(taskId: string): TaskSelection {
+  return {
+    type: SelectionType.Task,
+    taskId,
+  };
+}
 
 export function isTriggerSelection(
   selection: null | CurrentSelection

--- a/libs/plugins/stream-client/src/lib/core/state/cases/remove-stage.ts
+++ b/libs/plugins/stream-client/src/lib/core/state/cases/remove-stage.ts
@@ -1,0 +1,53 @@
+import { isEmpty } from 'lodash';
+
+import { FlogoStreamState } from '../stream.state';
+import { SelectionType } from '../../models/selection';
+
+export function removeStage(
+  prevState: FlogoStreamState,
+  nodeId: string
+): FlogoStreamState {
+  let { mainGraph: streamGraph, mainItems, currentSelection } = prevState;
+  if (isEmpty(mainItems)) {
+    return prevState;
+  }
+  const { [nodeId]: nodeToRemove, ...resultNodes } = streamGraph.nodes;
+  const { [nodeId]: itemToRemove, ...resultItems } = mainItems;
+  if (!nodeToRemove) {
+    return prevState;
+  }
+  streamGraph = { ...streamGraph, nodes: resultNodes };
+  mainItems = resultItems;
+  if (nodeToRemove.parents.length <= 0 && nodeToRemove.children.length <= 0) {
+    return {
+      ...prevState,
+      mainGraph: streamGraph,
+      mainItems,
+    };
+  }
+  const [parentId] = nodeToRemove.parents;
+  if (parentId) {
+    const parentNode = streamGraph.nodes[parentId];
+    parentNode.children = nodeToRemove.children;
+  }
+  const [childId] = nodeToRemove.children;
+  if (childId) {
+    const childNode = streamGraph.nodes[childId];
+    childNode.parents = nodeToRemove.parents;
+  }
+  if (!parentId) {
+    streamGraph.rootId = childId;
+  }
+  if (
+    currentSelection &&
+    currentSelection.type === SelectionType.Task &&
+    currentSelection.taskId === nodeToRemove.id
+  ) {
+    currentSelection = null;
+  }
+  return {
+    ...prevState,
+    mainGraph: streamGraph,
+    mainItems,
+  };
+}

--- a/libs/plugins/stream-client/src/lib/core/state/index.ts
+++ b/libs/plugins/stream-client/src/lib/core/state/index.ts
@@ -18,5 +18,8 @@ export * from './stream.actions';
 export * from './stream.reducers';
 export * from './stream.selectors';
 
+import * as StreamDiagramActions from './stream.actions';
+export { StreamDiagramActions };
+
 import * as TriggerActions from './triggers/triggers.actions';
 export { TriggerActions };

--- a/libs/plugins/stream-client/src/lib/core/state/stream.actions.ts
+++ b/libs/plugins/stream-client/src/lib/core/state/stream.actions.ts
@@ -10,6 +10,8 @@ export enum StreamActionType {
   UpdateMetadata = '[Stream] Update Metadata',
   SelectCreateStage = '[Stream] Add a stage',
   SelectStage = '[Stream] Select item',
+  SelectRemoveStage = '[Stream] Ask to delete stage',
+  DeleteStage = '[Stream] Confirm delete stage',
 }
 
 interface BaseStreamAction extends Action {
@@ -50,6 +52,16 @@ export class SelectStage implements BaseStreamAction {
   constructor(public payload: string | null) {}
 }
 
+export class SelectRemoveStage implements BaseStreamAction {
+  readonly type = StreamActionType.SelectRemoveStage;
+  constructor(public payload: string) {}
+}
+
+export class ConfirmDeleteStage implements BaseStreamAction {
+  readonly type = StreamActionType.DeleteStage;
+  constructor(public payload: string) {}
+}
+
 export type StreamActionsUnion =
   | Init
   | ChangeName
@@ -57,4 +69,6 @@ export type StreamActionsUnion =
   | ChangeDescription
   | StreamSaveSuccess
   | SelectCreateStage
-  | SelectStage;
+  | SelectStage
+  | SelectRemoveStage
+  | ConfirmDeleteStage;

--- a/libs/plugins/stream-client/src/lib/core/state/stream.actions.ts
+++ b/libs/plugins/stream-client/src/lib/core/state/stream.actions.ts
@@ -8,6 +8,8 @@ export enum StreamActionType {
   ChangeDescription = '[Stream] Description changed',
   StreamSaveSuccess = '[Stream] Save success',
   UpdateMetadata = '[Stream] Update Metadata',
+  SelectCreateStage = '[Stream] Add a stage',
+  SelectStage = '[Stream] Select item',
 }
 
 interface BaseStreamAction extends Action {
@@ -38,9 +40,21 @@ export class StreamSaveSuccess implements BaseStreamAction {
   readonly type = StreamActionType.StreamSaveSuccess;
 }
 
+export class SelectCreateStage implements BaseStreamAction {
+  readonly type = StreamActionType.SelectCreateStage;
+  constructor(public payload: string) {}
+}
+
+export class SelectStage implements BaseStreamAction {
+  readonly type = StreamActionType.SelectStage;
+  constructor(public payload: string | null) {}
+}
+
 export type StreamActionsUnion =
   | Init
   | ChangeName
   | RevertName
   | ChangeDescription
-  | StreamSaveSuccess;
+  | StreamSaveSuccess
+  | SelectCreateStage
+  | SelectStage;

--- a/libs/plugins/stream-client/src/lib/core/state/stream.reducers.ts
+++ b/libs/plugins/stream-client/src/lib/core/state/stream.reducers.ts
@@ -1,3 +1,4 @@
+import * as selectionFactory from '../models/stream/selection';
 import { INITIAL_STREAM_STATE, FlogoStreamState } from './stream.state';
 import { StreamActionsUnion, StreamActionType } from './stream.actions';
 
@@ -21,6 +22,16 @@ export function streamReducer(
       return {
         ...state,
         description: action.payload,
+      };
+    case StreamActionType.SelectCreateStage:
+      return {
+        ...state,
+        currentSelection: selectionFactory.makeInsertSelection(action.payload),
+      };
+    case StreamActionType.SelectStage:
+      return {
+        ...state,
+        currentSelection: selectionFactory.makeStageSelection(action.payload),
       };
   }
   return state;

--- a/libs/plugins/stream-client/src/lib/core/state/stream.reducers.ts
+++ b/libs/plugins/stream-client/src/lib/core/state/stream.reducers.ts
@@ -1,6 +1,7 @@
 import * as selectionFactory from '../models/stream/selection';
 import { INITIAL_STREAM_STATE, FlogoStreamState } from './stream.state';
 import { StreamActionsUnion, StreamActionType } from './stream.actions';
+import { removeStage } from './cases/remove-stage';
 
 export function streamReducer(
   state: FlogoStreamState = INITIAL_STREAM_STATE,
@@ -33,6 +34,8 @@ export function streamReducer(
         ...state,
         currentSelection: selectionFactory.makeStageSelection(action.payload),
       };
+    case StreamActionType.DeleteStage:
+      return removeStage(state, action.payload);
   }
   return state;
 }

--- a/libs/plugins/stream-client/src/lib/core/state/stream.selectors.ts
+++ b/libs/plugins/stream-client/src/lib/core/state/stream.selectors.ts
@@ -68,3 +68,8 @@ export const getInstalledFunctions = createSelector(
       }));
   }
 );
+
+export const selectGraph = createSelector(
+  selectStreamState,
+  streamState => streamState['mainGraph']
+);

--- a/libs/plugins/stream-client/src/lib/core/state/stream.selectors.ts
+++ b/libs/plugins/stream-client/src/lib/core/state/stream.selectors.ts
@@ -1,8 +1,14 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
-import { FlogoStreamState } from './stream.state';
+
+import { DiagramSelectionType } from '@flogo-web/lib-client/diagram';
 import { Dictionary } from '@flogo-web/lib-client/core';
 import { ContributionType, FunctionsSchema } from '@flogo-web/core';
+
+import { FlogoStreamState } from './stream.state';
 import { InstalledFunctionSchema } from '../interfaces';
+import { CurrentSelection, SelectionType } from '../models/selection';
+
+const GRAPH_NAME = 'mainGraph';
 
 export const selectStreamState = createFeatureSelector<FlogoStreamState>('stream');
 
@@ -71,5 +77,29 @@ export const getInstalledFunctions = createSelector(
 
 export const selectGraph = createSelector(
   selectStreamState,
-  streamState => streamState['mainGraph']
+  streamState => streamState[GRAPH_NAME]
+);
+
+export const selectCurrentSelection = createSelector(
+  selectStreamState,
+  (state: FlogoStreamState) => state.currentSelection
+);
+
+export const getDiagramSelection = createSelector(
+  selectCurrentSelection,
+  (selection: CurrentSelection) => {
+    if (selection && selection.type === SelectionType.InsertTask) {
+      return {
+        type: DiagramSelectionType.Insert,
+        taskId: selection.parentId,
+      };
+    } else if (selection && selection.type === SelectionType.Task) {
+      return {
+        type: DiagramSelectionType.Node,
+        taskId: selection.taskId,
+      };
+    } else {
+      return null;
+    }
+  }
 );

--- a/libs/plugins/stream-client/src/lib/stream-client.module.ts
+++ b/libs/plugins/stream-client/src/lib/stream-client.module.ts
@@ -6,6 +6,7 @@ import { EffectsModule } from '@ngrx/effects';
 import { HeaderModule as FlogoDesignerHeader } from '@flogo-web/lib-client/designer-header';
 import { LogsModule as FlogoLogsModule } from '@flogo-web/lib-client/logs';
 import { SharedModule as FlogoSharedModule } from '@flogo-web/lib-client/common';
+import { DiagramModule } from '@flogo-web/lib-client/diagram';
 import {
   StreamService,
   StreamSaveEffects,
@@ -18,6 +19,7 @@ import { StreamDesignerComponent } from './stream-designer';
 import { StreamDataResolver } from './stream-data.resolver';
 import { TriggersModule as FlogoStreamTriggersModule } from './triggers/triggers.module';
 import { MonacoEditorModule } from './shared/monaco-editor';
+import { StreamDiagramComponent } from './stream-diagram';
 
 @NgModule({
   imports: [
@@ -27,6 +29,7 @@ import { MonacoEditorModule } from './shared/monaco-editor';
     FlogoLogsModule,
     FlogoSharedModule,
     FlogoStreamTriggersModule,
+    DiagramModule,
     StoreModule.forFeature('stream', featureReducer),
     EffectsModule.forFeature([StreamSaveEffects, TriggerMappingsEffects]),
     RouterModule.forChild([
@@ -45,6 +48,6 @@ import { MonacoEditorModule } from './shared/monaco-editor';
     FlogoProfileService,
     MicroServiceModelConverter,
   ],
-  declarations: [StreamDesignerComponent],
+  declarations: [StreamDesignerComponent, StreamDiagramComponent],
 })
 export class StreamClientModule {}

--- a/libs/plugins/stream-client/src/lib/stream-client.module.ts
+++ b/libs/plugins/stream-client/src/lib/stream-client.module.ts
@@ -27,7 +27,6 @@ import { StreamDiagramComponent } from './stream-diagram';
     FlogoSharedModule,
     FlogoDesignerHeader,
     FlogoLogsModule,
-    FlogoSharedModule,
     FlogoStreamTriggersModule,
     DiagramModule,
     StoreModule.forFeature('stream', featureReducer),

--- a/libs/plugins/stream-client/src/lib/stream-designer/stream-designer.component.html
+++ b/libs/plugins/stream-client/src/lib/stream-designer/stream-designer.component.html
@@ -38,5 +38,8 @@
       </div>
     </div>
   </flogo-designer-header>
-  <flogo-stream-triggers></flogo-stream-triggers>
+  <div class="secondary-area">
+    <flogo-stream-triggers></flogo-stream-triggers>
+    <flogo-stream-diagram></flogo-stream-diagram>
+  </div>
 </div>

--- a/libs/plugins/stream-client/src/lib/stream-designer/stream-designer.component.less
+++ b/libs/plugins/stream-client/src/lib/stream-designer/stream-designer.component.less
@@ -119,3 +119,9 @@
 .stream-debugging {
   margin-right: 1rem;
 }
+
+.secondary-area {
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+}

--- a/libs/plugins/stream-client/src/lib/stream-diagram/index.ts
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/index.ts
@@ -1,0 +1,1 @@
+export * from './stream-diagram.component';

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.html
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.html
@@ -1,0 +1,1 @@
+<flogo-diagram [flow]="items$ | async"> </flogo-diagram>

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.html
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.html
@@ -1,1 +1,6 @@
-<flogo-diagram [flow]="items$ | async"> </flogo-diagram>
+<flogo-diagram
+  [flow]="items$ | async"
+  [selection]="currentSelection$ | async"
+  (action)="onDiagramAction($event)"
+>
+</flogo-diagram>

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.less
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.less
@@ -1,0 +1,13 @@
+@import (reference) '~@flogo-web/assets/styles/_variables';
+
+:host {
+  background-color: @gainsboro-nine;
+  overflow: auto;
+  flex: 1;
+  display: flex;
+  align-items: flex-start;
+}
+
+flogo-diagram {
+  flex: 1;
+}

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.spec.ts
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StreamDiagramComponent } from './stream-diagram.component';
+
+describe('StreamDiagramComponent', () => {
+  let component: StreamDiagramComponent;
+  let fixture: ComponentFixture<StreamDiagramComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [StreamDiagramComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StreamDiagramComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.ts
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnDestroy } from '@angular/core';
+import { Store, select } from '@ngrx/store';
+import { Observable } from 'rxjs';
+
+import { DiagramGraph, SingleEmissionSubject } from '@flogo-web/lib-client/core';
+
+import { StreamStoreState, selectGraph } from '../core/state';
+import { takeUntil } from 'rxjs/operators';
+
+@Component({
+  selector: 'flogo-stream-diagram',
+  templateUrl: './stream-diagram.component.html',
+  styleUrls: ['./stream-diagram.component.less'],
+})
+export class StreamDiagramComponent implements OnDestroy {
+  items$: Observable<DiagramGraph>;
+  private ngOnDestroy$ = SingleEmissionSubject.create();
+
+  constructor(private store: Store<StreamStoreState>) {
+    this.items$ = this.store.pipe(
+      select(selectGraph),
+      takeUntil(this.ngOnDestroy$)
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.ngOnDestroy$.emitAndComplete();
+  }
+}

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.ts
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.ts
@@ -54,6 +54,10 @@ export class StreamDiagramComponent implements OnDestroy {
         );
         break;
       case DiagramActionType.Remove:
+        this.store.dispatch(
+          new StreamDiagramActions.SelectRemoveStage((<DiagramActionSelf>action).id)
+        );
+        break;
       case DiagramActionType.Select:
         this.store.dispatch(
           new StreamDiagramActions.SelectStage((<DiagramActionSelf>action).id)

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.ts
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.ts
@@ -64,6 +64,8 @@ export class StreamDiagramComponent implements OnDestroy {
         );
         break;
       case DiagramActionType.Configure:
+        // streams-plugin-todo: implement the logic to allow user to configure the stages
+        break;
     }
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

Integrated the `flogo-diagram` library to the streams plugin code to allow users to design the streams. Current functionality achieved: 

1. Show existing stages in the diagram
2. Select a stage in the diagram
3. Delete a stage from the diagram. Can be tested in the branch [`1123-streams-diagram-test`](https://github.com/project-flogo/flogo-web/tree/1123-streams-diagram-test) where few of the stages are hard coded while initializing the stream state

WIP:
1. Allow users to add a stage to the stream
2. Configure the stage
