### PR TITLE
fix(ci): added libgconf to travis build to run e2e suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: required
 language: node_js
+addons:
+  apt:
+    # needed for cypress https://github.com/cypress-io/cypress/issues/1526
+    packages:
+      - libgconf-2-4
 node_js:
   - "10"
 cache:


### PR DESCRIPTION
Missing libgconf in travis build is preventing e2e suite to run.

It seems it's either cause by Chrome that stopped depending on libgconf or Travis using newer Ubuntu versions that don't install libgconf by default.