### PR TITLE
fix(stream-client): remove dangling output mappings when an output is deleted

### DIFF
--- a/libs/plugins/stream-client/src/lib/core/constants.ts
+++ b/libs/plugins/stream-client/src/lib/core/constants.ts
@@ -6,8 +6,6 @@ export enum FLOGO_TASK_TYPE {
 export const GRAPH_NAME = 'mainGraph';
 export const ITEMS_DICTIONARY_NAME = 'mainItems';
 
-export const FLOGO_ERROR_ROOT_NAME = '__error-trigger';
-
 export const TRIGGER_MENU_OPERATION = {
   SHOW_SETTINGS: 'show-settings',
   DELETE: 'delete',
@@ -22,4 +20,9 @@ export const MAPPING_TYPE = {
   LITERAL_ASSIGNMENT: TYPE_LITERAL_ASSIGNMENT,
   EXPRESSION_ASSIGNMENT: TYPE_EXPRESSION_ASSIGNMENT,
   OBJECT_TEMPLATE: TYPE_OBJECT_TEMPLATE,
+};
+
+export const ROOT_TYPES = {
+  STAGE: 'stage',
+  PIPELINE: 'pipeline',
 };

--- a/libs/plugins/stream-client/src/lib/core/state/clean-dangling-tasks-output-mappings.ts
+++ b/libs/plugins/stream-client/src/lib/core/state/clean-dangling-tasks-output-mappings.ts
@@ -1,24 +1,23 @@
 import { isEmpty, pick, fromPairs } from 'lodash';
 import { Dictionary } from '@flogo-web/lib-client/core';
+import { StreamMetadata } from '@flogo-web/plugins/stream-core';
 
 import { Item } from '../interfaces';
 import { FlogoStreamState } from './stream.state';
-import { ROOT_TYPES } from '../../shared/mapper/constants';
+import { ROOT_TYPES } from '../constants';
 
 /**
  * When stream schema's output change we need to remove the task mappings that were referencing them
- * @param state
+ * @param state {FlogoStreamState} stream state
+ * @param metadata {StreamMetadata} update stream metadata
  */
-export function cleanDanglingTaskOutputMappings(state: FlogoStreamState) {
-  let outputNames =
-    state.metadata && state.metadata.output
-      ? state.metadata.output.map(o => o.name)
-      : null;
-  if (!outputNames) {
-    return state;
-  }
+export function cleanDanglingTaskOutputMappings(
+  state: FlogoStreamState,
+  metadata: StreamMetadata
+) {
+  let outputNames = metadata && metadata.output ? metadata.output.map(o => o.name) : [];
 
-  outputNames = normalizeOutputs(outputNames);
+  outputNames = outputNames.map(prependPipeline);
 
   const cleanItems = itemCleaner(outputNames);
 
@@ -45,11 +44,18 @@ function cleanTasks(
   const changed: Array<[string, Item]> = Object.entries(items)
     .filter(shouldClean)
     .map(([taskId, task]: [string, Item]) => {
+      const taskOutputs = Object.keys(task.output || {}) || [];
+      const nonPipelineOutputs = taskOutputs.filter(
+        output => output.split('.')[0] !== ROOT_TYPES.PIPELINE
+      );
       return [
         taskId,
         {
           ...task,
-          output: pick(task.output, outputNames),
+          output: {
+            ...pick(task.output, nonPipelineOutputs),
+            ...pick(task.output, outputNames),
+          },
         },
       ] as [string, Item];
     });
@@ -63,6 +69,6 @@ function cleanTasks(
   return items;
 }
 
-function normalizeOutputs(outputs) {
-  return outputs.map(output => `$${ROOT_TYPES.PIPELINE}.${output}`);
+function prependPipeline(outputName: string) {
+  return `${ROOT_TYPES.PIPELINE}.${outputName}`;
 }

--- a/libs/plugins/stream-client/src/lib/core/state/stream.reducers.ts
+++ b/libs/plugins/stream-client/src/lib/core/state/stream.reducers.ts
@@ -56,7 +56,7 @@ export function streamReducer(
     case StreamActionType.DeleteStage:
       return removeStage(state, action.payload);
     case StreamActionType.UpdateMetadata:
-      state = cleanDanglingTaskOutputMappings(state);
+      state = cleanDanglingTaskOutputMappings(state, action.payload);
       return {
         ...state,
         metadata: {

--- a/libs/plugins/stream-client/src/lib/shared/mapper/constants.ts
+++ b/libs/plugins/stream-client/src/lib/shared/mapper/constants.ts
@@ -1,4 +1,0 @@
-export const ROOT_TYPES = {
-  STAGE: 'stage',
-  PIPELINE: 'pipeline',
-};

--- a/libs/plugins/stream-client/src/lib/shared/mapper/index.ts
+++ b/libs/plugins/stream-client/src/lib/shared/mapper/index.ts
@@ -1,6 +1,5 @@
 export * from './mapper.module';
 export * from './mapper.component';
-export * from './constants';
 
 export { MapExpression, Mappings, MapperState } from './models';
 export {

--- a/libs/plugins/stream-client/src/lib/shared/mapper/services/mapper-controller/mapper-controller-factory.service.ts
+++ b/libs/plugins/stream-client/src/lib/shared/mapper/services/mapper-controller/mapper-controller-factory.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import { ROOT_TYPES } from '../../constants';
 import {
   MapperContext,
   MapperTreeNode,
@@ -15,7 +14,7 @@ import { TreeService } from '../tree.service';
 import { TreeNodeFactoryService } from '../tree-node-factory.service';
 import { MapperController } from './mapper-controller';
 import { createMapperContext } from './create-mapper-context';
-import { InstalledFunctionSchema } from '../../../../core/interfaces';
+import { InstalledFunctionSchema, ROOT_TYPES } from '../../../../core';
 
 @Injectable()
 export class MapperControllerFactory {

--- a/libs/plugins/stream-client/src/lib/shared/mapper/utils/mapper-translator.ts
+++ b/libs/plugins/stream-client/src/lib/shared/mapper/utils/mapper-translator.ts
@@ -3,8 +3,7 @@ import { resolveExpressionType } from '@flogo-web/parser';
 import { EXPR_PREFIX, ValueType } from '@flogo-web/core';
 import { Dictionary } from '@flogo-web/lib-client/core';
 
-import { ROOT_TYPES } from '../constants';
-import { MAPPING_TYPE } from '../../../core';
+import { MAPPING_TYPE, ROOT_TYPES } from '../../../core';
 // todo: shared models should be moved to core
 import {
   StreamMetadata,

--- a/libs/plugins/stream-client/src/lib/stage-configurator/stage-configurator.component.ts
+++ b/libs/plugins/stream-client/src/lib/stage-configurator/stage-configurator.component.ts
@@ -19,12 +19,12 @@ import {
   CancelStageConfiguration,
   Item,
   CommitStageConfiguration,
+  ROOT_TYPES,
 } from '../core';
 import {
   MapperTranslator,
   MapperControllerFactory,
   MapperController,
-  ROOT_TYPES,
 } from '../shared/mapper';
 import { Tabs } from '../shared/tabs/models/tabs.model';
 import { StreamMetadata } from './models';
@@ -231,7 +231,7 @@ export class StageConfiguratorComponent implements OnInit, OnDestroy {
   private normalizeOutputs(outputs) {
     return outputs.map(output => ({
       ...output,
-      name: `$${ROOT_TYPES.PIPELINE}.${output.name}`,
+      name: `${ROOT_TYPES.PIPELINE}.${output.name}`,
     }));
   }
 


### PR DESCRIPTION


fixes #1161

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Deleting an output is not removing the dangling output mappings in a stage's configuration. Adding an output with the same name is pre-populated with previous mappings.


**What is the new behavior?**
Deleting an output should remove the dangling output mappings

