### PR TITLE
fix(server): engine not starting due to wrong default resource

### DIFF
--- a/apps/server/src/config/default-flogo.json
+++ b/apps/server/src/config/default-flogo.json
@@ -4,9 +4,5 @@
   "version": "0.0.1",
   "description": "Empty flogo app",
   "triggers": [],
-  "resources": [
-    {
-      "ref": "github.com/project-flogo/flow"
-    }
-  ]
+  "resources": []
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

The engine displays an error that it failed to created due to invalid resource id. This can be observe in the log file in `/dist/local/logs/engine.log`

```
{"message":"2019-09-09T17:20:02.379-0700\tDEBUG\t[flogo] -\tRegistering type alias 'coerce' for function [github.com/project-flogo/contrib/function/coerce]","level":"info","timestamp":"2019-09-10T00:20:02.399Z"}
{"message":"Failed to create engine: Invalid resource id: ","level":"info","timestamp":"2019-09-10T00:20:02.399Z"}

```

Or in the UI logs (currently broken, will be fixed by #1174 )
![Screen Shot 2019-09-09 at 5 20 43 PM](https://user-images.githubusercontent.com/17577698/64574955-5a607680-d326-11e9-84dc-16a35c1a4463.png)


**What is the new behavior?**

The error is fixed by removing the empty resource in the default empty app which is not needed anymore.

**Other information**:
**NOTE** that this change affects engine creation, so it will require for you to delete your `/dist/local/engines` folder.