### PR TITLE
fix: show trigger outputs and stream outputs in available data while configuring a trigger

### DIFF
--- a/libs/plugins/stream-client/src/lib/shared/mapper/services/mapper-controller/mapper-controller-factory.service.ts
+++ b/libs/plugins/stream-client/src/lib/shared/mapper/services/mapper-controller/mapper-controller-factory.service.ts
@@ -274,6 +274,9 @@ export class MapperControllerFactory {
     } else if (resolver === ROOT_TYPES.PIPELINE) {
       expressionHead = makeResolvable(nodeName);
       expressionTailParts = nodes.slice(1);
+    } else {
+      expressionHead = nodeName.indexOf('$') === -1 ? '$.' + nodeName : nodeName;
+      expressionTailParts = nodes.slice(1);
     }
     return [expressionHead]
       .concat(expressionTailParts.map(n => n.data.nodeName))

--- a/libs/plugins/stream-client/src/lib/shared/mapper/utils/mapper-translator.ts
+++ b/libs/plugins/stream-client/src/lib/shared/mapper/utils/mapper-translator.ts
@@ -50,6 +50,9 @@ export class MapperTranslator {
         case 'metadata':
           MapperTranslator.addStreamMetadataToOutputSchema(rootSchema, tile);
           break;
+        default:
+          rootSchema.properties[tile['name']] = { type: tile.type };
+          break;
       }
     });
     rootSchema.properties = Object.assign(rootSchema.properties, additionalSchemas);
@@ -164,9 +167,8 @@ export class MapperTranslator {
   static getRootType(tile: SchemaOutputs | StreamMetadata) {
     if (tile.type === 'metadata') {
       return ROOT_TYPES.PIPELINE;
-    } else if (tile.type === FLOGO_ACTIVITY_TYPE) {
-      return ROOT_TYPES.STAGE;
     }
+    return ROOT_TYPES.STAGE;
   }
 
   static makeValidator(): MappingsValidatorFn {

--- a/libs/plugins/stream-client/src/lib/stage-configurator/stage-configurator.component.ts
+++ b/libs/plugins/stream-client/src/lib/stage-configurator/stage-configurator.component.ts
@@ -160,38 +160,42 @@ export class StageConfiguratorComponent implements OnInit, OnDestroy {
     const scope = [{ ...streamMetadata }];
     const prevStageSchema = this.getPrevStageSchema(stageId, mainGraph, state);
     const schemaOutputs = this.getSchemaOutputs(prevStageSchema, 'previousStage');
-    if (!isEmpty(schemaOutputs)) {
+    if (schemaOutputs) {
       scope.push(schemaOutputs);
     }
     return scope;
   }
 
   private getSchemaOutputs(schema, stage): SchemaOutputs {
-    return {
-      type: schema.type,
-      stage,
-      outputs: schema.outputs,
-    };
+    if (!isEmpty(schema)) {
+      return {
+        type: schema.type,
+        stage,
+        outputs: schema.outputs,
+      };
+    }
+    return null;
   }
 
   private getOutputScope(activitySchema) {
     const scope = [];
     const currentSchemaOutputs = this.getSchemaOutputs(activitySchema, 'currentStage');
-    scope.push(currentSchemaOutputs);
+    if (currentSchemaOutputs) {
+      scope.push(currentSchemaOutputs);
+    }
     return scope;
   }
 
   private getPrevStageSchema(stageId, graph, state) {
     const { mainItems } = state;
-    let prevStageSchema = {};
-    if (stageId !== graph.rootId) {
-      const selectedNode = graph.nodes[stageId].parents || [];
-      const [selectedNodeParent] = selectedNode;
-      const prevStage = mainItems[selectedNodeParent];
+    const selectedNode = graph.nodes[stageId];
+    if (stageId !== graph.rootId && !isEmpty(selectedNode.parents)) {
+      const [prevNode] = selectedNode.parents;
+      const prevStage = mainItems[prevNode];
       const activityRef = prevStage['ref'];
-      prevStageSchema = state.schemas[activityRef];
+      return state.schemas[activityRef];
     }
-    return prevStageSchema;
+    return null;
   }
 
   private getStreamMetadata(streamState: FlogoStreamState): StreamMetadata {

--- a/libs/plugins/stream-client/src/lib/triggers/configurator/trigger-detail/settings/form-field/form-field.component.html
+++ b/libs/plugins/stream-client/src/lib/triggers/configurator/trigger-detail/settings/form-field/form-field.component.html
@@ -10,22 +10,15 @@
       (click)="enableField()"
     ></i>
   </label>
-  <!--streams-plugin-todo: use monaco-editor, remove textarea-->
-  <!--<monaco-editor
+  <monaco-editor
     *ngIf="useCodeEditor; else regularField"
-    class="settings-field settings-field&#45;&#45;code-editor"
+    class="settings-field settings-field--code-editor"
     #field
     [formValueChangeTransformerFn]="editorOut"
     [formValueWriteTransformerFn]="editorIn"
     [formControl]="settingControl"
-  ></monaco-editor>-->
-  <!--<textarea
-    *ngIf="useCodeEditor; else regularField"
-    class="settings-field settings-field&#45;&#45;code-editor"
-    #field
-    [formControl]="settingControl"
-  ></textarea>-->
-  <ng-template [ngIf]="!useCodeEditor">
+  ></monaco-editor>
+  <ng-template #regularField>
     <input
       class="settings-field"
       #field


### PR DESCRIPTION
show trigger outputs and stream outputs in available data while configuring a trigger.
Enable monaco-editor to input trigger and handler settings, includes review comments of pr#1163

Fixes #1168

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Unable to see the trigger outputs under Trigger Outputs while configuring the trigger-handler input mapping and stream outputs under Stream Outputs while configuring the trigger-handler reply mapping


**What is the new behavior?**
Able to see the available trigger outputs and stream outputs while configuring the trigger handler mappings
