### PR TITLE
fix(build): remove "SourceMap" warnings added by perspective webpack plugin

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -191,8 +191,7 @@
               "node_modules/monaco-editor/min/vs/loader.js"
             ],
             "customWebpackConfig": {
-              "path": "./extra-webpack.config.js",
-              "mergeStrategies": { "externals": "replace" }
+              "path": "./extra-webpack.config.js"
             }
           },
           "configurations": {

--- a/extra-webpack.config.js
+++ b/extra-webpack.config.js
@@ -1,5 +1,43 @@
 const PerspectivePlugin = require('@finos/perspective-webpack-plugin');
 
-module.exports = {
-  plugins: [new PerspectivePlugin()],
+module.exports = (config, options) => {
+  config.plugins.push(
+    new PerspectivePlugin(),
+    /*  temp fix to remove source map loader added by perspective plugin which causes compilation warnings */
+    {
+      apply(compiler) {
+        compiler.hooks.afterPlugins.tap(
+          'PerspectiveConfigFixerPlugin',
+          removePerspectiveSourceMapLoader
+        );
+      },
+    }
+  );
+  return config;
 };
+
+function removePerspectiveSourceMapLoader(compiler) {
+  const rules = (((compiler || {}).options || {}).module || {}).rules || [];
+  const ruleIndex = rules.findIndex(isPerspectiveSourceMapLoaderRule);
+  if (ruleIndex > -1) {
+    rules.splice(ruleIndex, 1);
+  }
+}
+
+function isSameRegex(regex1, regex2) {
+  return (
+    regex1 instanceof RegExp &&
+    regex2 instanceof RegExp &&
+    regex1.source === regex2.source
+  );
+}
+
+const matchRegex = /\.js$/;
+function isPerspectiveSourceMapLoaderRule(rule) {
+  return (
+    rule &&
+    rule.loader === 'source-map-loader' &&
+    rule.test &&
+    isSameRegex(matchRegex, rule.test)
+  );
+}


### PR DESCRIPTION


**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines: TBD
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Warnings due to perspective plugin configuration.


**What is the new behavior?**
Added custom plugin to remove unnecessary source map rule added by perspective webpack plugin.