### PR TITLE
feat: add lib-client schematic

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "services:stop": "docker-compose -p flogo-dev -f tools/docker/services.docker-compose.yml stop flogo-flow-service flogo-state-service",
     "services:clear": "docker-compose -p flogo-dev -f tools/docker/services.docker-compose.yml down",
     "flogo:new-resource": "./node_modules/.bin/nx workspace-schematic flogo-resource",
+    "flogo:new-client-lib": "./node_modules/.bin/nx workspace-schematic lib-client",
     "release": "npm-run-all -l release:pre release:client-version release:build-app:* release:post-build-apps release:build-engines release:copy-docker-files",
     "release:pre": "del dist/build",
     "release:build-app:server": "ng build server --prod",

--- a/tools/schematics/lib-client/files/README.md
+++ b/tools/schematics/lib-client/files/README.md
@@ -1,0 +1,5 @@
+# <%= classify(name) %>
+
+## How to use
+
+<!-- explain how to use this module -->

--- a/tools/schematics/lib-client/files/src/index.ts
+++ b/tools/schematics/lib-client/files/src/index.ts
@@ -1,0 +1,1 @@
+export { <%= classify(name) %>Module } from './<%= dasherize(name) %>.module';

--- a/tools/schematics/lib-client/index.ts
+++ b/tools/schematics/lib-client/index.ts
@@ -1,0 +1,100 @@
+import { CompilerOptions } from 'typescript';
+import {
+  chain,
+  externalSchematic,
+  Rule,
+  Tree,
+  SchematicContext,
+  apply,
+  url,
+  template,
+  move,
+  branchAndMerge,
+  mergeWith,
+  MergeStrategy,
+} from '@angular-devkit/schematics';
+import { strings } from '@angular-devkit/core';
+import { getWorkspace, formatFiles } from '@nrwl/workspace';
+
+const LIBS_PROJECT = 'lib-client';
+const ROOT_TS_CONFIG = 'tsconfig.json';
+
+export default function(schema: any): Rule {
+  return async (tree, context) => {
+    const workspace = await getWorkspace(tree);
+    const projectRoot = workspace.projects.get(LIBS_PROJECT).root;
+    return chain([
+      externalSchematic('@schematics/angular', 'module', {
+        name: schema.name,
+        project: LIBS_PROJECT,
+      }),
+      normalizeModuleStructure(projectRoot, schema.name),
+      addTemplateFiles(projectRoot, schema.name),
+      registerTsModule(projectRoot, schema.name),
+      formatFiles(),
+    ]);
+  };
+}
+
+function normalizeModuleStructure(projecRoot: string, name: string) {
+  const dasherizedName = strings.dasherize(name);
+  return move(
+    `${projecRoot}/lib/${dasherizedName}`,
+    `${projecRoot}/${dasherizedName}/src`
+  );
+}
+
+function addTemplateFiles(projecRoot: string, libName: string) {
+  const dasherizedName = strings.dasherize(libName);
+  return (tree: Tree, _context: SchematicContext) => {
+    const templateSource = apply(url('./files'), [
+      template({
+        ...strings,
+        name: libName,
+      }),
+      move(`${projecRoot}/${dasherizedName}`),
+    ]);
+    return chain([
+      branchAndMerge(
+        chain([mergeWith(templateSource, MergeStrategy.Overwrite)]),
+        MergeStrategy.Overwrite
+      ),
+    ])(tree, _context);
+  };
+}
+
+function registerTsModule(projectRoot, libName) {
+  return (tree: Tree) => {
+    const rootTsConfigSrc = tree.read(ROOT_TS_CONFIG);
+    const tsConfig: { compilerOptions: CompilerOptions } = JSON.parse(
+      rootTsConfigSrc.toString('utf-8')
+    );
+    const dasherizedName = strings.dasherize(libName);
+    insertModule(tsConfig, {
+      name: `@flogo-web/lib-client/${dasherizedName}`,
+      path: `${projectRoot}/${dasherizedName}/src/index.ts`,
+    });
+    JSON.stringify(tsConfig);
+    tree.overwrite(ROOT_TS_CONFIG, JSON.stringify(tsConfig));
+    return tree;
+  };
+}
+
+function insertModule(
+  tsConfig: { compilerOptions: CompilerOptions },
+  module: { name: string; path: string }
+) {
+  const paths = tsConfig.compilerOptions.paths;
+  const pathPairs = Object.entries(paths);
+  let lastIndex = pathPairs.length;
+  pathPairs.forEach(([key], index) => {
+    if (key.startsWith('@flogo-web/lib-client')) {
+      lastIndex = index;
+    }
+  });
+  pathPairs.splice(lastIndex + 1, 0, [module.name, [module.path]]);
+  tsConfig.compilerOptions.paths = pathPairs.reduce((all, [key, value]) => {
+    all[key] = value;
+    return all;
+  }, {});
+}

--- a/tools/schematics/lib-client/schema.json
+++ b/tools/schematics/lib-client/schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "lib-client",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Library name",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    }
+  },
+  "required": ["name"]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a schematic to automate the creation, setup and registration of shared client libraries under `lib-client` package.

To use run:

```bash
yarn flogo:new-client-lib <lib-name>
```

Where name is the desired name for the library, for example for 'context-panel'

```bash
yarn flogo:new-client-lib context-panel
```

This command will:

1. Add a new module in `libs/lib-client` that follows the same structure as the other modules in lib-client
2. Register a new entry in the root tsconfig.json as `@flogo-web/lib-client/<lib-name>` so the generated library can be used in other packages

## Motivation and Context

The intention is to eliminate the multiple steps necessary to create a new client lib and consolidate it into one single step.

## How has this been tested?

Manual testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.