### PR TITLE
[1153] Deleting a resource will clean the triggers and handlers

### DIFF
--- a/apps/server/src/modules/apps/handlers-service.ts
+++ b/apps/server/src/modules/apps/handlers-service.ts
@@ -156,7 +156,6 @@ function removeHandlerWhereResourceId(
     const handlerToRemoveIndex = trigger.handlers.findIndex(isHandlerToRemove);
     if (handlerToRemoveIndex > -1) {
       trigger.handlers.splice(handlerToRemoveIndex, 1);
-      break;
     }
   }
   return app;

--- a/apps/server/src/modules/apps/triggers.ts
+++ b/apps/server/src/modules/apps/triggers.ts
@@ -210,6 +210,20 @@ export class AppTriggersService {
     }
     return false;
   }
+
+  async purgeTriggersByAppId(appId: string) {
+    const [app] = this.appsDb
+      .chain()
+      .find(<LokiQuery<any>>{ id: appId }, true)
+      .data();
+    if (!app) {
+      return false;
+    }
+
+    app.triggers = app.triggers.filter(trigger => trigger.handlers.length > 0);
+    this.appsDb.update(app);
+    return true;
+  }
 }
 
 function validateNameUnique(name: string, app: App, triggerId: string) {

--- a/libs/lib-client/core/src/services/app-resource.service.ts
+++ b/libs/lib-client/core/src/services/app-resource.service.ts
@@ -55,8 +55,8 @@ export class AppResourceService {
       });
   }
 
-  deleteResource(flowId) {
-    return this.resourceService.deleteResource(flowId);
+  deleteResource(resourceId) {
+    return this.resourceService.deleteResource(resourceId);
   }
 
   /**

--- a/libs/plugins/flow-client/src/lib/core/flow.service.ts
+++ b/libs/plugins/flow-client/src/lib/core/flow.service.ts
@@ -68,10 +68,8 @@ export class FlogoFlowService {
     }
   }
 
-  deleteFlow(flowId, triggerId) {
-    return this.appResourceService
-      .deleteResourceWithTrigger(flowId, triggerId)
-      .toPromise();
+  deleteFlow(flowId) {
+    return this.appResourceService.deleteResource(flowId).toPromise();
   }
 
   listFlowsByName(appId, name) {

--- a/libs/plugins/flow-client/src/lib/flow.component.ts
+++ b/libs/plugins/flow-client/src/lib/flow.component.ts
@@ -169,7 +169,7 @@ export class FlowComponent implements OnInit, OnDestroy {
       .subscribe(app => {
         const triggerDetails = this.getTriggerCurrentFlow(app, this.flowState.id);
         this._flowService
-          .deleteFlow(this.flowId, triggerDetails ? triggerDetails.id : null)
+          .deleteFlow(this.flowId)
           .then(() => this.navigateToApp())
           .then(() =>
             this.notifications.success({

--- a/libs/plugins/stream-client/src/lib/core/stream.service.ts
+++ b/libs/plugins/stream-client/src/lib/core/stream.service.ts
@@ -159,7 +159,7 @@ export class StreamService {
             }).result
         ),
         filter(result => result === ConfirmationResult.Confirm),
-        switchMap(() => this.appResourceService.deleteResourceWithTrigger(stream.id))
+        switchMap(() => this.appResourceService.deleteResource(stream.id))
       )
       .subscribe(
         () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes a bug where handlers have references to deleted resources, causing an exception while exporting / building a binary of the application

## Motivation and Context
As per #1153, when we delete a resource, only first found trigger handler is deleted and other handlers used to maintain the reference to the deleted resource. 

Also if the trigger is not used by any other resources, then it was still maintained under existing triggers. Causing a lot of unused triggers in the application. There was no way to delete the un-referenced error

What problem does it solve?
When a resource is deleted, all the handlers associated with that resource are deleted. Also each delete resource operation is going to purge the unused triggers in the application

## How has this been tested?
Manual testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
