### PR TITLE
[1196] - Made handlers as a required property of the triggers

### DIFF
--- a/libs/lib-server/core/src/lib/schemas/v1.0.0/tests/app.spec.ts
+++ b/libs/lib-server/core/src/lib/schemas/v1.0.0/tests/app.spec.ts
@@ -102,6 +102,7 @@ describe('JSONSchema: App', () => {
     const trigger = {
       id: 'trigger1',
       ref: 'some_path_to_repo/trigger/cli',
+      handlers: [],
     };
     const resource = { id: 'flow:test', data: {} };
     const action = { id: 'action_1', ref: 'some_path_to_repo/stream', settings: {} };

--- a/libs/lib-server/core/src/lib/schemas/v1.0.0/trigger.json
+++ b/libs/lib-server/core/src/lib/schemas/v1.0.0/trigger.json
@@ -3,7 +3,7 @@
   "$id": "http://github.com/project-flogo/flogo-web/schemas/1.0.0/trigger.json",
   "type": "object",
   "additionalProperties": false,
-  "required": ["id", "ref"],
+  "required": ["id", "ref", "handlers"],
   "properties": {
     "id": {
       "type": "string",


### PR DESCRIPTION
## Description
When there are no handlers provided for a trigger, the application import is failing with an exception. 

This ticket Fixes #1196.

Describe your changes in detail
I have updated the trigger schema and made handlers as required property. I followed the trigger configuration schema definition of flogo-core.

## How has this been tested?
Manual testing

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
