### PR TITLE
fix: subscribe to simulation process status

### DIFF
--- a/libs/plugins/stream-client/src/lib/run-stream/run-stream-button/run-stream-button.component.html
+++ b/libs/plugins/stream-client/src/lib/run-stream/run-stream-button/run-stream-button.component.html
@@ -1,5 +1,5 @@
 <flogo-stream-run-action-status
-  [status]="simulatorStatus$"
+  [status]="simulatorStatus$ | async"
   [disableRunStream]="disableRunStream"
   (run)="runStream()"
   (pause)="pauseSimulation()"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

On run stream, run button is not changing to stop/pause/resume buttons

## Motivation and Context

This is needed to pause/resume/stop stream

## How has this been tested?

1) Create an app and an action stream
2) Add a stage, click run stream, upload a csv file
3) Click run stream
4) Now will be able to see stop/pause/resume

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
