### PR TITLE
Sorts the contributions in add-activity modal with sub-flow contrib always at the top.

### DIFF
--- a/libs/plugins/flow-client/src/lib/core/state/flow/flow.selectors.ts
+++ b/libs/plugins/flow-client/src/lib/core/state/flow/flow.selectors.ts
@@ -307,9 +307,10 @@ export const getInstalledActivities = createSelector(
         ref: schema.ref,
       }))
       .sort((activity1, activity2) => {
-        const isSubflow = activity1.ref === CONTRIB_REFS.SUBFLOW;
-        if (isSubflow) {
+        if (activity1.ref === CONTRIB_REFS.SUBFLOW) {
           return -1;
+        } else if (activity2.ref === CONTRIB_REFS.SUBFLOW) {
+          return 1;
         }
         return ('' + activity1.title).localeCompare(activity2.title);
       });


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the functionality that sorts the activities list in activity-list component. It make sures that 'subflow' activity is always on the top and sorts the other activities alphabetically.


## How has this been tested?
Manually



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
