### PR TITLE
merge: close upload popover on clicking run stream

### DIFF
--- a/libs/plugins/stream-client/src/lib/run-stream/run-stream.component.ts
+++ b/libs/plugins/stream-client/src/lib/run-stream/run-stream.component.ts
@@ -122,6 +122,7 @@ export class RunStreamComponent implements OnInit, OnDestroy {
       new StreamActions.SimulatorConfigurationChange({ inputMappingType })
     );
     this.simulationStarted.emit();
+    this.runStreamService.closePopover();
   }
 
   stopSimulation() {

--- a/libs/plugins/stream-client/src/lib/run-stream/run-stream.service.ts
+++ b/libs/plugins/stream-client/src/lib/run-stream/run-stream.service.ts
@@ -24,7 +24,7 @@ export class RunStreamService {
   ) {
     const portal = this.createPortal(contentComponent, customTokens);
     overlayRef.attach(portal);
-    overlayRef.backdropClick().subscribe(() => this.close());
+    overlayRef.backdropClick().subscribe(() => this.closePopover());
   }
 
   private createPortal<T>(
@@ -64,7 +64,7 @@ export class RunStreamService {
       ]);
   }
 
-  close() {
+  closePopover() {
     this.overlayRef.dispose();
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Upload popover is not closing after clicking run stream unless clicked outside the popover
Fixes #1239

## How has this been tested?

Tested manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/47237691/68127839-a7368700-ff3c-11e9-95bf-07fbc8ca7b22.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
