### PR TITLE
Revert "Support the engine configuration file to the local engine"

### DIFF
--- a/apps/server/src/config/app-config.js
+++ b/apps/server/src/config/app-config.js
@@ -47,9 +47,6 @@ const config = {
   defaultFlogoDescriptorPath:
     process.env.FLOGO_WEB_DEFAULT_DESCRIPTOR ||
     path.join(rootPath, 'config', 'default-flogo.json'),
-  defaultFlogoEngineConfigPath:
-    process.env.FLOGO_WEB_DEFAULT_ENGINE_CONFIG ||
-    path.join(rootPath, 'config', 'engine.json'),
   libVersion,
   app: {
     basePath: '/v1/api',

--- a/apps/server/src/config/default-flogo.json
+++ b/apps/server/src/config/default-flogo.json
@@ -3,7 +3,9 @@
   "type": "flogo:app",
   "version": "0.0.1",
   "description": "Empty flogo app",
-  "imports": [],
+  "imports": [
+    "github.com/project-flogo/stream/service/telemetry"
+  ],
   "triggers": [],
   "resources": []
 }

--- a/apps/server/src/config/engine.json
+++ b/apps/server/src/config/engine.json
@@ -1,6 +1,0 @@
-{
-  "type": "flogo:engine",
-  "imports": [
-    "github.com/project-flogo/stream/service/telemetry"
-  ]
-}

--- a/apps/server/src/init/bootstrap-engine.ts
+++ b/apps/server/src/init/bootstrap-engine.ts
@@ -1,12 +1,10 @@
 import { getInitializedEngine, EngineProcess } from '../modules/engine';
 import { syncTasks } from '../modules/contrib-install-controller/sync-tasks';
-import { config } from '../config';
 
 export async function boostrapEngine(enginePath: string, engineProcess: EngineProcess) {
   const engine = await getInitializedEngine(enginePath, {
     forceCreate: !!process.env['FLOGO_WEB_ENGINE_FORCE_CREATION'],
   });
-  await engine.updateEngineConfig(config.defaultFlogoEngineConfigPath);
   await engine.build();
   // engineProcess.start(engine.getProjectDetails());
   await syncTasks(engine);

--- a/apps/server/src/modules/engine/engine.ts
+++ b/apps/server/src/modules/engine/engine.ts
@@ -1,12 +1,9 @@
 import * as path from 'path';
 
-import { FlogoError } from '@flogo-web/lib-server/core';
-
-import { createFolder as ensureDir, copyFile, fileExists } from '../../common/utils/file';
+import { createFolder as ensureDir } from '../../common/utils/file';
 
 import { copyBinaryToDestination, removeDir } from './file-utils';
 import { processHost } from '../../common/utils/process';
-import { ERROR_TYPES } from '../../common/errors';
 import { buildAndCopyBinary } from './build/binary';
 import { buildPlugin } from './build/plugin';
 
@@ -18,7 +15,6 @@ import { TYPE_BUILD, TYPE_TEST, BuildOptions, Options } from './options';
 
 const DIR_TEST_BIN = 'bin-test';
 const DIR_BUILD_BIN = 'bin-build';
-const FILE_ENGINE_CONFIG = 'engine.json';
 
 export interface EngineProjectDetails {
   projectName: string;
@@ -81,15 +77,6 @@ class Engine {
         console.timeEnd('engine:create');
         return result;
       });
-  }
-
-  updateEngineConfig(configPath) {
-    if (!fileExists(configPath)) {
-      throw new FlogoError('Config file not found', {
-        type: ERROR_TYPES.COMMON.NOT_FOUND,
-      });
-    }
-    return copyFile(configPath, path.join(this.path, FILE_ENGINE_CONFIG));
   }
 
   remove() {


### PR DESCRIPTION
The engine config files are not available in the server application after build. Reverting #1250 