### PR TITLE
Separated test engine configuration from the actual application JSON

### DIFF
--- a/apps/server/src/config/app-config.js
+++ b/apps/server/src/config/app-config.js
@@ -47,6 +47,9 @@ const config = {
   defaultFlogoDescriptorPath:
     process.env.FLOGO_WEB_DEFAULT_DESCRIPTOR ||
     path.join(rootPath, 'config', 'default-flogo.json'),
+  defaultFlogoEngineConfigPath:
+    process.env.FLOGO_WEB_DEFAULT_ENGINE_CONFIG ||
+    path.join(rootPath, 'config', 'test-engine.config.json'),
   libVersion,
   app: {
     basePath: '/v1/api',

--- a/apps/server/src/config/default-flogo.json
+++ b/apps/server/src/config/default-flogo.json
@@ -3,9 +3,7 @@
   "type": "flogo:app",
   "version": "0.0.1",
   "description": "Empty flogo app",
-  "imports": [
-    "github.com/project-flogo/stream/service/telemetry"
-  ],
+  "imports": [],
   "triggers": [],
   "resources": []
 }

--- a/apps/server/src/config/test-engine.config.json
+++ b/apps/server/src/config/test-engine.config.json
@@ -1,0 +1,6 @@
+{
+  "type": "flogo:engine",
+  "imports": [
+    "github.com/project-flogo/stream/service/telemetry"
+  ]
+}

--- a/apps/server/src/configure-engines.ts
+++ b/apps/server/src/configure-engines.ts
@@ -6,7 +6,12 @@ import { AppsService } from './modules/apps';
 import { initDb, flushAndCloseDb } from './common/db';
 
 initDb({ autosave: false })
-  .then(() => getInitializedEngine(config.defaultEngine.path, { forceCreate: false }))
+  .then(() =>
+    getInitializedEngine(config.defaultEngine.path, {
+      forceCreate: false,
+      bundleEngineConfig: true,
+    })
+  )
   .then(engine => syncTasks(engine))
   .then(() => {
     console.log('[log] init test engine done');

--- a/apps/server/src/configure-engines.ts
+++ b/apps/server/src/configure-engines.ts
@@ -9,7 +9,7 @@ initDb({ autosave: false })
   .then(() =>
     getInitializedEngine(config.defaultEngine.path, {
       forceCreate: false,
-      bundleEngineConfig: true,
+      useEngineConfig: true,
     })
   )
   .then(engine => syncTasks(engine))

--- a/apps/server/src/init/bootstrap-engine.ts
+++ b/apps/server/src/init/bootstrap-engine.ts
@@ -4,7 +4,7 @@ import { syncTasks } from '../modules/contrib-install-controller/sync-tasks';
 export async function boostrapEngine(enginePath: string, engineProcess: EngineProcess) {
   const engine = await getInitializedEngine(enginePath, {
     forceCreate: !!process.env['FLOGO_WEB_ENGINE_FORCE_CREATION'],
-    bundleEngineConfig: true,
+    useEngineConfig: true,
   });
   await engine.build();
   // engineProcess.start(engine.getProjectDetails());

--- a/apps/server/src/init/bootstrap-engine.ts
+++ b/apps/server/src/init/bootstrap-engine.ts
@@ -4,6 +4,7 @@ import { syncTasks } from '../modules/contrib-install-controller/sync-tasks';
 export async function boostrapEngine(enginePath: string, engineProcess: EngineProcess) {
   const engine = await getInitializedEngine(enginePath, {
     forceCreate: !!process.env['FLOGO_WEB_ENGINE_FORCE_CREATION'],
+    bundleEngineConfig: true,
   });
   await engine.build();
   // engineProcess.start(engine.getProjectDetails());

--- a/apps/server/src/modules/engine/engine.ts
+++ b/apps/server/src/modules/engine/engine.ts
@@ -1,9 +1,12 @@
 import * as path from 'path';
 
-import { createFolder as ensureDir } from '../../common/utils/file';
+import { FlogoError } from '@flogo-web/lib-server/core';
+
+import { createFolder as ensureDir, copyFile, fileExists } from '../../common/utils/file';
 
 import { copyBinaryToDestination, removeDir } from './file-utils';
 import { processHost } from '../../common/utils/process';
+import { ERROR_TYPES } from '../../common/errors';
 import { buildAndCopyBinary } from './build/binary';
 import { buildPlugin } from './build/plugin';
 
@@ -15,6 +18,7 @@ import { TYPE_BUILD, TYPE_TEST, BuildOptions, Options } from './options';
 
 const DIR_TEST_BIN = 'bin-test';
 const DIR_BUILD_BIN = 'bin-build';
+const FILE_ENGINE_CONFIG = 'engine.json';
 
 export interface EngineProjectDetails {
   projectName: string;
@@ -77,6 +81,16 @@ class Engine {
         console.timeEnd('engine:create');
         return result;
       });
+  }
+
+  updateEngineConfig(configPath) {
+    if (!fileExists(configPath)) {
+      throw new FlogoError(`Config file ${configPath} not found`, {
+        type: ERROR_TYPES.COMMON.NOT_FOUND,
+      });
+    }
+    logger.info('Updating the engine configuration');
+    return copyFile(configPath, path.join(this.path, FILE_ENGINE_CONFIG));
   }
 
   remove() {

--- a/apps/server/src/modules/engine/registry.ts
+++ b/apps/server/src/modules/engine/registry.ts
@@ -84,7 +84,24 @@ export function getContribInstallationController(
   });
 }
 
-async function createEngine(engine, opts) {
+/**
+ * Create engine in the local engines folder with the application json provided through defaultFlogoDescriptorPath
+ *
+ * @param engine {Engine} the engine details
+ * @param opts {object} options required while creating the engine
+ * @param opts.defaultFlogoDescriptorPath {string} Path to the application descriptor
+ * @param opts.useContribBundle {boolean} Whether to install the default contributions
+ * @param opts.useEngineConfig {boolean} Whether to copy default engine configuration file to the engine's root folder
+ * @returns {boolean | Error}
+ */
+async function createEngine(
+  engine,
+  opts: {
+    defaultFlogoDescriptorPath: string;
+    useContribBundle: boolean;
+    useEngineConfig: boolean;
+  }
+) {
   logger.warn('Engine does not exist. Creating...');
   const { defaultFlogoDescriptorPath, useContribBundle, useEngineConfig } = opts;
   try {


### PR DESCRIPTION
feat(server): Added support to engine configuration file for local engine.

  - Added a new app config property `defaultFlogoEngineConfigPath`
  - Users can set environment variable FLOGO_WEB_DEFAULT_ENGINE_CONFIG to set the path to default engine config
  - Users can provide a different path while updating the engine config

## Description

The latest flogo core provides support to maintain different engine configuration files which will be allow us to build the flogo-web's local engine binary with different test configurations.

## How has this been tested?

Manual testing. 
1. Should not effect the new engine creation while the server start up
2. The telemetry service must be installed to the local engine through this engine config file
3. Should maintain a `engine.json` file in local engine's folder before building the local engine

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
