### PR TITLE
fix(stream): support `streamURI` by default

### DIFF
--- a/libs/lib-server/core/src/lib/extensions/plugin.ts
+++ b/libs/lib-server/core/src/lib/extensions/plugin.ts
@@ -19,6 +19,7 @@ export interface ResourceType<TResourceData = unknown> {
   type: string;
   ref: string;
   resourceType: string;
+  additionalResourceTypes?: string[];
   import: ResourceImporter<TResourceData>;
   export: ResourceExporter<TResourceData>;
 }

--- a/libs/plugins/stream-core/src/lib/engine.ts
+++ b/libs/plugins/stream-core/src/lib/engine.ts
@@ -1,7 +1,8 @@
 import { MetadataAttribute } from '@flogo-web/core';
 
 export interface StreamActionSettings {
-  pipelineURI: string;
+  pipelineURI?: string;
+  streamURI?: string;
   groupBy: string;
 }
 

--- a/libs/plugins/stream-server/src/lib/constants.ts
+++ b/libs/plugins/stream-server/src/lib/constants.ts
@@ -1,2 +1,3 @@
-export const STREAM_POINTER = 'pipelineURI';
+export const PIPELINE_POINTER = 'pipelineURI';
+export const STREAM_POINTER = 'streamURI';
 export const RESOURCE_TYPE = 'stream';

--- a/libs/plugins/stream-server/src/lib/import/handler.ts
+++ b/libs/plugins/stream-server/src/lib/import/handler.ts
@@ -6,7 +6,7 @@ import {
 } from '@flogo-web/lib-server/core';
 import { Handler, FlogoAppModel } from '@flogo-web/core';
 
-import { STREAM_POINTER } from '../constants';
+import { PIPELINE_POINTER, STREAM_POINTER } from '../constants';
 import { StreamSchemas } from '../schemas';
 
 export function importHandler(handler, context: HandlerImportContext): Handler {
@@ -16,8 +16,11 @@ export function importHandler(handler, context: HandlerImportContext): Handler {
   if (errors) {
     throw new ValidationError('Stream handler validation error', errors);
   }
+  const resourcePointer =
+    actionDetails[STREAM_POINTER] || actionDetails[PIPELINE_POINTER];
+  const resourceId = parseResourceIdFromResourceUri(resourcePointer);
   return {
     ...handler,
-    resourceId: parseResourceIdFromResourceUri(actionDetails[STREAM_POINTER]),
+    resourceId,
   };
 }

--- a/libs/plugins/stream-server/src/lib/import/stream.ts
+++ b/libs/plugins/stream-server/src/lib/import/stream.ts
@@ -9,7 +9,7 @@ import {
 } from '@flogo-web/plugins/stream-core';
 import { ResourceImportContext, ValidationError } from '@flogo-web/lib-server/core';
 
-import { STREAM_POINTER } from '../constants';
+import { PIPELINE_POINTER, STREAM_POINTER } from '../constants';
 import { makeResourceValidator } from './make-resource-validator';
 
 const KEY_STAGE_INDEX = 2;
@@ -41,9 +41,12 @@ function extractMetadata(
 ): StreamMetadata {
   const metadata = { ...resource.metadata };
   const originalResourceId = getOriginalId(normalizedResourceIds, resource.id);
+  const resourcePointerName = originalResourceId.startsWith('pipeline')
+    ? PIPELINE_POINTER
+    : STREAM_POINTER;
   const actionSettings = actionsManager.getSettingsForResourceId(
     originalResourceId,
-    STREAM_POINTER
+    resourcePointerName
   ) as StreamActionSettings;
   return {
     input: metadata.input || [],

--- a/libs/plugins/stream-server/src/lib/schemas/action-settings.json
+++ b/libs/plugins/stream-server/src/lib/schemas/action-settings.json
@@ -3,8 +3,16 @@
   "$id": "http://github.com/project-flogo/flogo-web/schemas/1.0.0/stream/action-settings.json",
   "type": "object",
   "additionalProperties": false,
-  "required": ["pipelineURI"],
+  "anyOf": [
+    { "required": ["pipelineURI"] },
+    { "required": ["streamURI"] }
+  ],
   "properties": {
+    "streamURI": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^res:\/\/.+"
+    },
     "pipelineURI": {
       "type": "string",
       "minLength": 1,

--- a/libs/plugins/stream-server/src/lib/stream-server.ts
+++ b/libs/plugins/stream-server/src/lib/stream-server.ts
@@ -21,7 +21,8 @@ export const streamPlugin: FlogoPlugin = {
     // register resource type
     server.resources.addType({
       type: RESOURCE_TYPE,
-      resourceType: 'pipeline',
+      resourceType: 'stream',
+      additionalResourceTypes: ['pipeline'],
       ref: RESOURCE_REF,
       import: {
         resource(data: Resource<StreamData>, context: ResourceImportContext) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding `additionalResourceTypes` to the server plugin information to allow registering a plugin for more than one type of resource.

This is mainly to provide backwards support for streams due to the changes explained in #1269.

This PR also updates the stream server plugin to support both `streamURI`/`stream:` and `pipelineURI`/`pipeline:`.

## Motivation and Context

Fixes https://github.com/project-flogo/flogo-web/issues/1269
