### PR TITLE
fix: debug panel inputs were not updated

### DIFF
--- a/libs/plugins/flow-client/src/lib/debug-panel/utils.spec.ts
+++ b/libs/plugins/flow-client/src/lib/debug-panel/utils.spec.ts
@@ -13,7 +13,8 @@ describe('debug-panel.utils.matchFormWithExecutionResult()', function() {
           { name: 'otherval', value: 'wrong' },
           { name: 'message', value: 'wrong' },
           { name: 'notFound', value: 'hello' },
-        ]
+        ],
+        'something_1'
       )
     ).toEqual([
       { name: 'otherval', value: 33 },
@@ -30,7 +31,7 @@ describe('debug-panel.utils.mergeFormWithOutputs()', function() {
         return null;
       },
     };
-    expect(() => mergeFormWithOutputs(formGroup as FormGroup, {})).not.toThrowError();
+    expect(() => mergeFormWithOutputs(formGroup as FormGroup, {}, '')).not.toThrowError();
   });
 
   it('should not try to update the form if there are no executionResults', function() {
@@ -43,7 +44,7 @@ describe('debug-panel.utils.mergeFormWithOutputs()', function() {
       },
     };
     spyOn(outputGroup, 'patchValue');
-    mergeFormWithOutputs(formGroup as FormGroup, null);
+    mergeFormWithOutputs(formGroup as FormGroup, null, '');
     expect(outputGroup.patchValue).not.toHaveBeenCalled();
   });
 
@@ -59,7 +60,7 @@ describe('debug-panel.utils.mergeFormWithOutputs()', function() {
     };
     spyOn(outputGroup, 'patchValue');
 
-    mergeFormWithOutputs(formGroup as FormGroup, {});
+    mergeFormWithOutputs(formGroup as FormGroup, {}, '');
     expect(outputGroup.patchValue).toHaveBeenCalled();
   });
 });

--- a/libs/plugins/flow-client/src/lib/debug-panel/utils.ts
+++ b/libs/plugins/flow-client/src/lib/debug-panel/utils.ts
@@ -3,22 +3,33 @@ import { Dictionary, StepAttribute } from '@flogo-web/lib-client/core';
 
 export function mergeFormWithOutputs(
   form: FormGroup,
-  lastExecutionResult: Dictionary<StepAttribute>
+  lastExecutionResult: Dictionary<StepAttribute>,
+  taskId: string
 ) {
   const outputFields = form && form.get('output.formFields');
   if (outputFields && lastExecutionResult) {
-    const outputs = matchFormWithExecutionResult(lastExecutionResult, outputFields.value);
+    const outputs = matchFormWithExecutionResult(
+      lastExecutionResult,
+      outputFields.value,
+      taskId
+    );
     outputFields.patchValue(outputs);
   }
   return form;
 }
 
-export function matchFormWithExecutionResult(step: StepAttribute, formValues: any[]) {
+export function matchFormWithExecutionResult(
+  step: StepAttribute,
+  formValues: any[],
+  selectedTaskId
+) {
   const outputs = new Map(
-    Object.keys(step).map<[string, string]>(attr => {
-      const [taskType, taskId, attribute] = attr.split('.');
-      return [attribute, step[attr]];
-    })
+    Object.keys(step)
+      .map<[string, string]>(attr => {
+        const [taskType, taskId, attribute] = attr.split('.');
+        return taskId === selectedTaskId ? [attribute, step[attr]] : null;
+      })
+      .filter(attribute => !!attribute)
   );
   const newOutput = formValues.map(field => {
     const value = outputs.has(field.name) ? outputs.get(field.name) : null;

--- a/libs/plugins/flow-client/src/lib/flow.component.ts
+++ b/libs/plugins/flow-client/src/lib/flow.component.ts
@@ -204,7 +204,7 @@ export class FlowComponent implements OnInit, OnDestroy {
       const mainFlowChanges = step.flowChanges[StepFlowType.MainFlow];
       const taskIdsExecuted = taskIdsOfCurrentStep(mainFlowChanges.tasks);
       // @ts-ignore:disable-legacy-type-interference
-      return taskIdsExecuted.find(taskID);
+      return taskIdsExecuted.find(stepTaskId => stepTaskId === taskID);
     });
   }
 

--- a/libs/plugins/flow-client/src/lib/shared/dynamic-form/object/object-type.component.html
+++ b/libs/plugins/flow-client/src/lib/shared/dynamic-form/object/object-type.component.html
@@ -12,7 +12,6 @@
     [formControl]="fieldGroup.get('value')"
     [formValueWriteTransformerFn]="transformValueIn"
     [formValueChangeTransformerFn]="transformValueOut"
-    [shouldUpdateValue]="shouldUpdateEditorValue"
   >
   </monaco-editor>
 </div>

--- a/libs/plugins/flow-client/src/lib/shared/dynamic-form/object/object-type.component.ts
+++ b/libs/plugins/flow-client/src/lib/shared/dynamic-form/object/object-type.component.ts
@@ -13,8 +13,6 @@ export class ObjectTypeComponent {
   @Input() fieldControl: BaseField<any>;
   @Input() readonly?: boolean;
   editorOptions = { language: 'json' };
-  // once initialized we don't want updates to propagate back
-  shouldUpdateEditorValue = () => this.readonly;
 
   transformValueIn(value) {
     return isNil(value) || isString(value) ? value : JSON.stringify(value, null, 2);


### PR DESCRIPTION
## Description

Fixes #1272 
This change also fixes a console error we see in the browser when the client code is trying to see if the activity has run or not.

## How has this been tested?
1. Have a flow with 2 rest activities (with one of them having some input data in debug panel preferably the later one)
2. Test run a flow from the beginning
3. Toggle between those 2 rest activities
4. You should be able to see that the inputs are updated with their respective data

5. Now select the 2nd rest activity and click on 'Run from this tile' in the debug panel. 
6. Toggle between the 2nd and 1st rest activity. The first activity being not ran in this cycle should have empty fields

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
