### PR TITLE
use latest release of streams and don't sync imports during server startup

### DIFF
--- a/apps/server/src/init/bootstrap-engine.ts
+++ b/apps/server/src/init/bootstrap-engine.ts
@@ -6,6 +6,6 @@ export async function boostrapEngine(enginePath: string) {
     forceCreate: !!process.env['FLOGO_WEB_ENGINE_FORCE_CREATION'],
     useEngineConfig: true,
   });
-  await engine.build({ syncImports: true });
+  await engine.build();
   await syncTasks(engine);
 }

--- a/apps/server/src/modules/engine/registry.ts
+++ b/apps/server/src/modules/engine/registry.ts
@@ -11,15 +11,9 @@ const engineRegistry: { [key: string]: any } = {};
 let defaultResourceTypes: string[] = [];
 
 export function setDefaultResourceTypes(resourceTypes: string[]) {
-  defaultResourceTypes = [...resourceTypes]
-    .filter(ref => ref !== __DEV_RESOURCE_REF_PLACEHOLDER)
-    .map(ref => {
-      // todo: Remove the following temporary fix for broken `flogo build` command caused by stream v0.2.0
-      if (ref === 'github.com/project-flogo/stream') {
-        return 'github.com/project-flogo/stream@master';
-      }
-      return ref;
-    });
+  defaultResourceTypes = [...resourceTypes].filter(
+    ref => ref !== __DEV_RESOURCE_REF_PLACEHOLDER
+  );
 }
 
 /**

--- a/apps/server/src/modules/engine/registry.ts
+++ b/apps/server/src/modules/engine/registry.ts
@@ -135,6 +135,7 @@ export function initEngine(engine, options) {
   const skipContribLoad = options && options.skipContribLoad;
   const skipBundleInstall = options && options.skipBundleInstall;
   const useEngineConfig = options && options.useEngineConfig;
+  let isNewEngine = false;
 
   return engine
     .exists()
@@ -146,11 +147,12 @@ export function initEngine(engine, options) {
     })
     .then(shouldCreateNewEngine => {
       if (shouldCreateNewEngine) {
+        isNewEngine = true;
         return createEngine(engine, {
           defaultFlogoDescriptorPath,
           useContribBundle: !skipBundleInstall,
           useEngineConfig,
-        });
+        }).then(() => engine.build({ syncImports: true }));
       }
       return true;
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

use latest release of streams and don't sync imports during server startup

## Motivation and Context

- depend on released version of streams instead of master
- speed up startup time #1274


