### PR TITLE
[1277] Windows environment now maintain single instance of flogo-web process

### DIFF
--- a/apps/server/src/modules/engine/process/exec-controller.ts
+++ b/apps/server/src/modules/engine/process/exec-controller.ts
@@ -49,12 +49,13 @@ export function execEngine(
 
 function startProcess(engineName: string, cwd: string, env: Record<string, string>) {
   const commandEnv = { ...process.env, ...DEFAULT_ENV, ...env };
+  return spawn(getCommand(engineName), [], { cwd, env: commandEnv });
+}
 
-  let command = `./${engineName}`;
-  let args = [];
+function getCommand(engineName: string) {
   if (processHost.isWindows()) {
-    command = process.env.comspec;
-    args = ['/c', engineName];
+    return engineName;
   }
-  return spawn(command, args, { cwd, env: commandEnv });
+
+  return `./${engineName}`;
 }


### PR DESCRIPTION
fix(server): Maintaining the flogo-web process properly in the engine-process-director in windows

Fixes #1277

## Description

Earlier we used to depend on `cmd.exe` to start the flogo-web process. Because of which the [EngineProcessDirector](https://github.com/project-flogo/flogo-web/blob/cc17197dbbd0b5c94257eb04d1bb414e979a16f5/apps/server/src/modules/engine/process/engine-process-director.ts#L26) was not maintaining the actual flogo-web process.

As the flogo-web process is not killed properly, the second time we are trying to start the process for simulation / flow testing, we see an error saying port is already in use. 
 
The changes should only effect the windows local environment.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
