### PR TITLE
[707] - Fix edge case where the dropping a tile as last element does not save

### DIFF
--- a/libs/lib-client/diagram/src/index.ts
+++ b/libs/lib-client/diagram/src/index.ts
@@ -16,4 +16,4 @@ export { SELECTED_INSERT_TILE_CLASS, BUTTON_INSERT_CLASS } from './lib/constants
 export { DiagramModule } from './lib/diagram.module';
 export { trackTileByFn } from './lib/tiles/track-tile-by';
 export { updateLinks } from './lib/drag-tiles';
-export { DragTileService } from './lib/drag-tiles';
+export { DragTileService, DragTilePosition } from './lib/drag-tiles';

--- a/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.html
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.html
@@ -23,6 +23,8 @@
   [cdkDropListDisabled]="isReadOnly"
   [cdkDropListEnterPredicate]="restrictTileDrop"
   (cdkDropListDropped)="moveTile($event)"
+  (mouseenter)="updateDraggingState(draggingPosition.INSIDE, $event.buttons)"
+  (mouseleave)="updateDraggingState(draggingPosition.OUTSIDE, $event.buttons)"
 >
   <ng-template
     ngFor

--- a/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.ts
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.ts
@@ -15,7 +15,7 @@ import { actionEventFactory } from '../action-event-factory';
 import { RowIndexService } from '../shared';
 import { rowAnimations } from './diagram-row.animations';
 import { trackTileByFn } from '../tiles/track-tile-by';
-import { DragTileService, TilesGroupedByZone } from '../drag-tiles';
+import { DragTileService, DragTilePosition, TilesGroupedByZone } from '../drag-tiles';
 
 @Component({
   selector: 'flogo-diagram-row',
@@ -32,6 +32,7 @@ export class DiagramRowComponent implements OnChanges {
   @Output() action = new EventEmitter<DiagramAction>();
 
   tileTypes = TileType;
+  draggingPosition = DragTilePosition;
   groupedTiles: TilesGroupedByZone<Tile>;
   trackTileBy = trackTileByFn;
 
@@ -80,4 +81,8 @@ export class DiagramRowComponent implements OnChanges {
   restrictTileDrop = (dragEvent: CdkDrag) => {
     return this.dragService.isTileAllowedToDropInRow(dragEvent.data, this.rowIndex);
   };
+
+  updateDraggingState(pos: DragTilePosition, buttons: number) {
+    this.dragService.changeDraggingTracker(pos, buttons);
+  }
 }

--- a/libs/lib-client/diagram/src/lib/drag-tiles/index.ts
+++ b/libs/lib-client/diagram/src/lib/drag-tiles/index.ts
@@ -1,3 +1,3 @@
 export * from './update-links';
-export * from './drag-tile.service';
+export { DragTilePosition, DragTileService } from './drag-tile.service';
 export * from './interface';

--- a/libs/lib-client/diagram/src/lib/index.ts
+++ b/libs/lib-client/diagram/src/lib/index.ts
@@ -7,4 +7,4 @@ export {
 export { BUTTON_INSERT_CLASS, SELECTED_INSERT_TILE_CLASS } from './constants';
 export { DiagramComponent } from './diagram/diagram.component';
 export { DiagramModule } from './diagram.module';
-export { DragTileService } from './drag-tiles';
+export { DragTileService, DragTilePosition } from './drag-tiles';

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.html
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.html
@@ -4,6 +4,8 @@
     cdkDropList
     cdkDropListOrientation="horizontal"
     (cdkDropListDropped)="moveStage($event)"
+    (mouseenter)="updateDraggingState(draggingPosition.INSIDE, $event.buttons)"
+    (mouseleave)="updateDraggingState(draggingPosition.OUTSIDE, $event.buttons)"
   >
     <flogo-diagram-tile-task
       *ngFor="let tile of tiles; trackBy: trackTileBy"

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.ts
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.ts
@@ -16,6 +16,7 @@ import {
   trackTileByFn,
   InsertTile,
   DragTileService,
+  DragTilePosition,
 } from '@flogo-web/lib-client/diagram';
 
 import {
@@ -37,6 +38,7 @@ export class StreamDiagramComponent implements OnDestroy {
   tiles: Tile[];
   // by default should be the root tile
   insertTile: InsertTile;
+  draggingPosition = DragTilePosition;
   trackTileBy = trackTileByFn;
   availableSlots: number;
   placeholders = [];
@@ -99,6 +101,10 @@ export class StreamDiagramComponent implements OnDestroy {
     if (dropActionData) {
       this.store.dispatch(new StreamActions.MoveStage(dropActionData));
     }
+  }
+
+  updateDraggingState(pos: DragTilePosition, buttons: number) {
+    this.dragService.changeDraggingTracker(pos, buttons);
   }
 
   private updateAvailableSlots(streamTiles) {


### PR DESCRIPTION
## Description
I have removed dependency of flag [`CdkDragDrop.isPointerOverContainer`](https://material.angular.io/cdk/drag-drop/api#CdkDragDrop) to know if the drop is inside or outside a droplist. The library set's a wrong value to the flag when trying to place the tile as the last element of the row. 

The changes are in `@flogo-web/lib-client/diagram` and `@flogo-web/plugins/stream-client`.

## How has this been tested?

Manally tested the flows and stream designer page with following scenarios:

- [x] Drag an item and drop it anywhere except last tile in the same row
- [x] Drag an item and drop it anywhere except last tile in any other row
- [x] Drag an item and drop it as a last time in the same row
- [x] Drag an item and drop it as a last time in a different row
- [x] Drag an item and drop it in empty place

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
