### PR TITLE
fix(plugins-flow-client): reset rootId when all nodes are deleted

### DIFF
--- a/libs/plugins/flow-client/src/lib/core/models/flow/remove-node.ts
+++ b/libs/plugins/flow-client/src/lib/core/models/flow/remove-node.ts
@@ -19,7 +19,7 @@ export function removeNode(
   flowGraph = { ...flowGraph, nodes: resultNodes };
   items = resultItems;
   if (nodeToRemove.parents.length <= 0 && nodeToRemove.children.length <= 0) {
-    return { flowGraph, items };
+    return { flowGraph: { ...flowGraph, rootId: null }, items };
   }
 
   const [parentId] = nodeToRemove.parents;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When all the tasks all deleted form the diagram, rootId in the graph has to be reset to null in the state

![image](https://user-images.githubusercontent.com/47237691/82051564-bfe7dc80-96d7-11ea-9b3c-223472c10f04.png)


## How has this been tested?

Tested manually using Redux DevTools browser extension

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
