### PR TITLE
[707] drag and drop visuals

### DIFF
--- a/libs/lib-client/diagram/src/lib/diagram.module.ts
+++ b/libs/lib-client/diagram/src/lib/diagram.module.ts
@@ -12,11 +12,20 @@ import { TileTaskComponent } from './tiles/tile-task.component';
 import { TileBranchComponent } from './tiles/tile-branch.component';
 import { TileSsvgComponent } from './tiles/tiles-svg';
 import { DragTileService } from './drag-tiles';
+import { TilePlaceholderComponent } from './tiles/tile-placeholder.component';
+import { TilePreviewComponent } from './tiles/tile-preview.component';
 
 @NgModule({
   imports: [CommonModule, LanguageModule, DragDropModule],
 
-  exports: [DiagramComponent, TileInsertComponent, TileTaskComponent, TileSsvgComponent],
+  exports: [
+    DiagramComponent,
+    TileInsertComponent,
+    TileTaskComponent,
+    TileSsvgComponent,
+    TilePlaceholderComponent,
+    TilePreviewComponent,
+  ],
   declarations: [
     DiagramComponent,
     DiagramRowComponent,
@@ -24,6 +33,8 @@ import { DragTileService } from './drag-tiles';
     TileBranchComponent,
     TileTaskComponent,
     TileSsvgComponent,
+    TilePlaceholderComponent,
+    TilePreviewComponent,
   ],
   providers: [DragTileService],
 })

--- a/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.html
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.html
@@ -36,7 +36,7 @@
       cdkDrag
       cdkDragBoundary="flogo-diagram"
       @tileTask
-      [class.disable-tile]="isDragging && disableTile(tile?.task?.id)"
+      [class.is-disabled]="isDragging && disableTile(tile?.task?.id)"
       [tile]="tile"
       [cdkDragData]="tile?.task?.id"
       [currentSelection]="selection"
@@ -68,7 +68,7 @@
   <flogo-diagram-tile-task
     *ngIf="tile.type === tileTypes.Task"
     @tileTask
-    [class.disable-tile]="isDragging"
+    [class.is-disabled]="isDragging"
     [tile]="tile"
     [currentSelection]="selection"
     [isReadOnly]="isReadOnly"
@@ -84,14 +84,14 @@
     class="tile tile--slot"
     [ngClass]="{
       'tile--placeholder': tile.type === tileTypes.Placeholder,
-      'hide-tile': isDragging
+      'is-hidden': isDragging
     }"
   ></div>
   <flogo-diagram-tile-insert
     *ngIf="tile.type === tileTypes.Insert"
     @tileInsert
     class="tile--slot"
-    [class.hide-tile]="isDragging"
+    [class.is-hidden]="isDragging"
     [tile]="tile"
     [currentSelection]="selection"
     (select)="onInsertSelected($event)"

--- a/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.html
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.html
@@ -82,12 +82,16 @@
     @tileGeneric
     [@.disabled]="tile.type === tileTypes.Placeholder"
     class="tile tile--slot"
-    [class.tile--placeholder]="tile.type === tileTypes.Placeholder"
+    [ngClass]="{
+      'tile--placeholder': tile.type === tileTypes.Placeholder,
+      'hide-tile': isDragging
+    }"
   ></div>
   <flogo-diagram-tile-insert
     *ngIf="tile.type === tileTypes.Insert"
     @tileInsert
     class="tile--slot"
+    [class.hide-tile]="isDragging"
     [tile]="tile"
     [currentSelection]="selection"
     (select)="onInsertSelected($event)"

--- a/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.html
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.html
@@ -36,6 +36,7 @@
       cdkDrag
       cdkDragBoundary="flogo-diagram"
       @tileTask
+      [class.disable-tile]="isDragging && disableTile(tile?.task?.id)"
       [tile]="tile"
       [cdkDragData]="tile?.task?.id"
       [currentSelection]="selection"
@@ -67,6 +68,7 @@
   <flogo-diagram-tile-task
     *ngIf="tile.type === tileTypes.Task"
     @tileTask
+    [class.disable-tile]="isDragging"
     [tile]="tile"
     [currentSelection]="selection"
     [isReadOnly]="isReadOnly"

--- a/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.html
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.html
@@ -45,7 +45,17 @@
       (remove)="onTaskAction($event)"
       (configure)="onTaskAction($event)"
       (cdkDragStarted)="onTaskDragStart($event)"
-    ></flogo-diagram-tile-task>
+    >
+      <flogo-diagram-tile-placeholder
+        *cdkDragPlaceholder
+      ></flogo-diagram-tile-placeholder>
+      <ng-template cdkDragPreview [matchSize]="true">
+        <flogo-diagram-tile-preview
+          [id]="tile?.task?.id"
+          [title]="tile?.task?.title"
+        ></flogo-diagram-tile-preview>
+      </ng-template>
+    </flogo-diagram-tile-task>
   </ng-template>
 </div>
 <ng-template

--- a/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.less
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.less
@@ -41,6 +41,9 @@
     .tile--slot {
       opacity: 1;
     }
+    .hide-tile {
+      opacity: 0;
+    }
   }
 }
 

--- a/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.less
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.less
@@ -41,12 +41,12 @@
     .tile--slot {
       opacity: 1;
     }
-    .hide-tile {
+    .is-hidden {
       opacity: 0;
     }
   }
 }
 
-.disable-tile {
+.is-disabled {
   opacity: 0.35;
 }

--- a/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.less
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.less
@@ -43,3 +43,7 @@
     }
   }
 }
+
+.disable-tile {
+  opacity: 0.35;
+}

--- a/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.ts
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.ts
@@ -28,6 +28,7 @@ export class DiagramRowComponent implements OnChanges {
   @Input() row: Tile[];
   @Input() selection: DiagramSelection;
   @Input() rowIndex: number;
+  @Input() isDragging: boolean;
   @HostBinding('class.is-readonly') @Input() isReadOnly = false;
   @Output() action = new EventEmitter<DiagramAction>();
 
@@ -39,6 +40,10 @@ export class DiagramRowComponent implements OnChanges {
 
   restrictTileDrop = (dragEvent: CdkDrag) => {
     return this.dragService.isTileAllowedToDropInRow(dragEvent.data, this.rowIndex);
+  };
+
+  disableTile = id => {
+    return id && !this.dragService.getTileDropAllowStatus(id).allow;
   };
 
   constructor(

--- a/libs/lib-client/diagram/src/lib/diagram/diagram.component.html
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram.component.html
@@ -7,6 +7,7 @@
     [rowIndex]="tileMatrix.length - rowIndex - 1"
     [selection]="selection"
     [isReadOnly]="isReadOnly"
+    [isDragging]="isDragging"
     (action)="onAction($event)"
     class="diagram-row"
   >

--- a/libs/lib-client/diagram/src/lib/tiles/tile-placeholder.component.ts
+++ b/libs/lib-client/diagram/src/lib/tiles/tile-placeholder.component.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'flogo-diagram-tile-placeholder',
+  template: `
+    <svg
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      xmlns="http://www.w3.org/2000/svg"
+      width="128"
+      height="60"
+      viewBox="0 0 128 62"
+    >
+      <g class="tile" fill="none" fill-rule="evenodd" transform="translate(2 1)">
+        <path
+          class="tile__stroke"
+          d="M117.27 60H0l11.264-29.92L0 0h117.371L128 30.376z"
+        />
+      </g>
+    </svg>
+  `,
+})
+export class TilePlaceholderComponent {}

--- a/libs/lib-client/diagram/src/lib/tiles/tile-preview.component.html
+++ b/libs/lib-client/diagram/src/lib/tiles/tile-preview.component.html
@@ -1,0 +1,35 @@
+<div class="task-container">
+  <div class="shape-container">
+    <svg
+      xmlns:xlink="http://www.w3.org/1999/xlink"
+      xmlns="http://www.w3.org/2000/svg"
+      width="128"
+      height="62"
+      viewBox="0 0 128 66"
+    >
+      <g class="tile" fill="none" fill-rule="evenodd">
+        <path
+          class="tile__shadow"
+          [attr.filter]="shadow"
+          d="M117.27 60H0l11.264-29.92L0 0h117.371L128 30.376z"
+        />
+        <path
+          class="tile__bg"
+          [attr.fill]="bgFill"
+          d="M117.27 60H0l11.264-29.92L0 0h117.371L128 30.376z"
+        />
+      </g>
+    </svg>
+  </div>
+  <div class="content">
+    <div class="content__items">
+      <i class="content__icon content__icon-activity flogo-icon-activity-gear"></i>
+      <div class="content__text content__text--title">
+        {{ title }}
+      </div>
+      <div class="content__text content__text--id">
+        {{ id }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/libs/lib-client/diagram/src/lib/tiles/tile-preview.component.ts
+++ b/libs/lib-client/diagram/src/lib/tiles/tile-preview.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input } from '@angular/core';
+import { SvgRefFixerService } from '@flogo-web/lib-client/core';
+
+@Component({
+  selector: 'flogo-diagram-tile-preview',
+  templateUrl: './tile-preview.component.html',
+  styleUrls: ['./tile-task.component.less'],
+})
+export class TilePreviewComponent {
+  @Input()
+  title: string;
+  @Input()
+  id: string;
+
+  constructor(private svgFixer: SvgRefFixerService) {}
+
+  get bgFill() {
+    return this.svgFixer.getFixedRef('url(#flogo-diagram-tile__bg)');
+  }
+
+  get shadow() {
+    return this.svgFixer.getFixedRef('url(#flogo-diagram-tile__shadow--preview)');
+  }
+}

--- a/libs/lib-client/diagram/src/lib/tiles/tiles-svg.component.html
+++ b/libs/lib-client/diagram/src/lib/tiles/tiles-svg.component.html
@@ -65,5 +65,17 @@
         values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"
       />
     </filter>
+    <filter id="flogo-diagram-tile__shadow--preview">
+      <feOffset dx="-2" dy="2" in="SourceAlpha" result="shadowOffsetOuter3"></feOffset>
+      <feGaussianBlur
+        in="shadowOffsetOuter3"
+        result="shadowBlurOuter3"
+        stdDeviation="4"
+      ></feGaussianBlur>
+      <feColorMatrix
+        in="shadowBlurOuter3"
+        values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.3 0"
+      ></feColorMatrix>
+    </filter>
   </defs>
 </svg>

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.html
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.html
@@ -18,7 +18,17 @@
       (select)="selectStage($event)"
       (remove)="onDiagramAction($event)"
       (configure)="onDiagramAction($event)"
-    ></flogo-diagram-tile-task>
+    >
+      <flogo-diagram-tile-placeholder
+        *cdkDragPlaceholder
+      ></flogo-diagram-tile-placeholder>
+      <ng-template cdkDragPreview [matchSize]="true">
+        <flogo-diagram-tile-preview
+          [id]="tile?.task?.id"
+          [title]="tile?.task?.title"
+        ></flogo-diagram-tile-preview>
+      </ng-template>
+    </flogo-diagram-tile-task>
   </div>
   <flogo-diagram-tile-insert
     fgAddStage


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implement visual designs for tile drag and drop. Changes include
- [x] Highlight applicable drop zones on drag start - Grey out not applicable tiles
- [x] Visual for drag tile placeholder - Any empty space
- [x] Visual for drag tile preview - Preview tile looks same as an activity tile's default state irrespective of tile current state (selection state, ran state, error state etc...)
- [X] Hide placeholder and insert tiles of a row on drag start

part of #707 

## How has this been tested?

Tested manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
