### PR TITLE
feat(lib-client): drag drop visuals

### DIFF
--- a/apps/client/src/assets/main.less
+++ b/apps/client/src/assets/main.less
@@ -802,3 +802,7 @@ code {
   top: 1px;
   font-size: 0.9em;
 }
+
+.cursor-move {
+  cursor: move;
+}

--- a/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.html
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.html
@@ -82,16 +82,14 @@
     @tileGeneric
     [@.disabled]="tile.type === tileTypes.Placeholder"
     class="tile tile--slot"
-    [ngClass]="{
-      'tile--placeholder': tile.type === tileTypes.Placeholder,
-      'is-hidden': isDragging
-    }"
+    [class.tile--placeholder]="tile.type === tileTypes.Placeholder"
+    [hidden]="isDragging"
   ></div>
   <flogo-diagram-tile-insert
     *ngIf="tile.type === tileTypes.Insert"
     @tileInsert
     class="tile--slot"
-    [class.is-hidden]="isDragging"
+    [hidden]="isDragging"
     [tile]="tile"
     [currentSelection]="selection"
     (select)="onInsertSelected($event)"

--- a/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.less
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram-row.component.less
@@ -41,9 +41,6 @@
     .tile--slot {
       opacity: 1;
     }
-    .is-hidden {
-      opacity: 0;
-    }
   }
 }
 

--- a/libs/lib-client/diagram/src/lib/diagram/diagram.component.ts
+++ b/libs/lib-client/diagram/src/lib/diagram/diagram.component.ts
@@ -52,9 +52,7 @@ export class DiagramComponent implements OnChanges, OnDestroy {
     this.trackRowBy = diagramRowTracker(this);
     this.dragService.isDragging$
       .pipe(takeUntil(this.ngDestroy$))
-      .subscribe(isDragging => {
-        this.isDragging = isDragging;
-      });
+      .subscribe(isDragging => (this.isDragging = isDragging));
   }
 
   ngOnChanges({ flow: flowChange, isReadOnly: readOnlyChange }: SimpleChanges) {

--- a/libs/lib-client/diagram/src/lib/drag-tiles/drag-tile.service.ts
+++ b/libs/lib-client/diagram/src/lib/drag-tiles/drag-tile.service.ts
@@ -324,6 +324,11 @@ export class DragTileService {
 
   updateDragAction(dragState) {
     this.isDraggingSubscriber.next(dragState);
+    this.toggleCursorStyle();
+  }
+
+  toggleCursorStyle() {
+    document.querySelector('body').classList.toggle('cursor-move');
   }
 
   resetDropAllowStatus() {

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.html
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.html
@@ -18,6 +18,7 @@
       (select)="selectStage($event)"
       (remove)="onDiagramAction($event)"
       (configure)="onDiagramAction($event)"
+      (cdkDragStarted)="onStageDragStart()"
     >
       <flogo-diagram-tile-placeholder
         *cdkDragPlaceholder
@@ -38,8 +39,13 @@
     [currentSelection]="currentSelection"
     (select)="addStage()"
     [class.visible-on-hover]="tiles.length"
+    [hidden]="isDragging"
   ></flogo-diagram-tile-insert>
   <div class="tile-placeholders">
-    <div class="tile-placeholder visible-on-hover" *ngFor="let i of placeholders"></div>
+    <div
+      class="tile-placeholder visible-on-hover"
+      [hidden]="isDragging"
+      *ngFor="let i of placeholders"
+    ></div>
   </div>
 </div>

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.ts
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.ts
@@ -42,6 +42,7 @@ export class StreamDiagramComponent implements OnDestroy {
   trackTileBy = trackTileByFn;
   availableSlots: number;
   placeholders = [];
+  isDragging: boolean;
   private ngOnDestroy$ = SingleEmissionSubject.create();
 
   constructor(
@@ -67,6 +68,9 @@ export class StreamDiagramComponent implements OnDestroy {
         };
         this.updateAvailableSlots(streamTiles);
       });
+    this.dragService.isDragging$
+      .pipe(takeUntil(this.ngOnDestroy$))
+      .subscribe(isDragging => (this.isDragging = isDragging));
   }
 
   ngOnDestroy(): void {
@@ -105,6 +109,10 @@ export class StreamDiagramComponent implements OnDestroy {
 
   updateDraggingState(pos: DragTilePosition, buttons: number) {
     this.dragService.changeDraggingTracker(pos, buttons);
+  }
+
+  onStageDragStart() {
+    this.dragService.updateDragAction(true);
   }
 
   private updateAvailableSlots(streamTiles) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- [x] Hide insert and placeholder tiles for streams on stage drag start
- [x] Show 'move' cursor for drag tile
		 I initially wanted to implemented this overriding cursor style by targeting the drag tile. But due to some technical limitation(https://github.com/angular/components/issues/15090) in CDK had to toggle the style for body.

## How has this been tested?

Tested manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
