### PR TITLE
feat(plugins-stream-client): add stage in between

### DIFF
--- a/libs/plugins/stream-client/src/lib/core/state/cases/stage-item-created.ts
+++ b/libs/plugins/stream-client/src/lib/core/state/cases/stage-item-created.ts
@@ -45,7 +45,14 @@ function addNewNode(graph: DiagramGraph, newNode: GraphNode): DiagramGraph {
   const isInsertBetween = parentId ? parent.children.length > 0 : !!rootId;
   if (parent) {
     if (isInsertBetween) {
+      const child = {
+        ...nodes[parent.children[0]],
+      };
       node.children = [...parent.children];
+      nodes = {
+        ...nodes,
+        [child.id]: { ...child, parents: [node.id] },
+      };
     }
     nodes = {
       ...nodes,

--- a/libs/plugins/stream-client/src/lib/core/state/cases/stage-item-created.ts
+++ b/libs/plugins/stream-client/src/lib/core/state/cases/stage-item-created.ts
@@ -39,21 +39,36 @@ function addNewNode(graph: DiagramGraph, newNode: GraphNode): DiagramGraph {
     },
     status: {},
   };
-  const parent = graph.nodes[parentId];
   let nodes = graph.nodes;
+  let rootId = graph.rootId;
+  const parent = graph.nodes[parentId];
+  const isInsertBetween = parentId ? parent.children.length > 0 : !!rootId;
   if (parent) {
+    if (isInsertBetween) {
+      node.children = [...parent.children];
+    }
     nodes = {
       ...nodes,
       [parent.id]: { ...parent, children: [node.id] },
     };
   } else {
-    graph = {
-      ...graph,
-      rootId: node.id,
-    };
+    // case when adding a tile before the root tile of the diagram
+    if (isInsertBetween) {
+      const child = {
+        ...nodes[graph.rootId],
+        parents: [node.id],
+      };
+      node.children = [graph.rootId];
+      nodes = {
+        ...nodes,
+        [child.id]: child,
+      };
+    }
+    rootId = node.id;
   }
   return {
     ...graph,
+    rootId,
     nodes: {
       ...nodes,
       [node.id]: node,

--- a/libs/plugins/stream-client/src/lib/stage-add/add-stage.directive.ts
+++ b/libs/plugins/stream-client/src/lib/stage-add/add-stage.directive.ts
@@ -11,7 +11,12 @@ import {
   HostBinding,
 } from '@angular/core';
 
-import { DiagramSelection, DiagramSelectionType } from '@flogo-web/lib-client/diagram';
+import {
+  BUTTON_INSERT_CLASS,
+  DiagramSelection,
+  DiagramSelectionType,
+  SELECTED_INSERT_TILE_CLASS,
+} from '@flogo-web/lib-client/diagram';
 
 import { AddActivityService } from './add-activity.service';
 
@@ -53,7 +58,9 @@ export class AddStageDirective implements OnInit, OnChanges, OnDestroy {
       } else {
         setTimeout(() => {
           this.buttonOpacity = 1;
-          const selectedInsertTile = this.el.nativeElement;
+          const selectedInsertTile = this.el.nativeElement.querySelector(
+            `.${SELECTED_INSERT_TILE_CLASS} .${BUTTON_INSERT_CLASS}`
+          );
           this.addStageService.open(selectedInsertTile, currentSelection.taskId);
         }, BRANCH_ANIMATION_DURATION);
       }

--- a/libs/plugins/stream-client/src/lib/stage-configurator/models/commit-stage-configuration.ts
+++ b/libs/plugins/stream-client/src/lib/stage-configurator/models/commit-stage-configuration.ts
@@ -32,7 +32,6 @@ function graphUpdate(state, item): FlogoStreamState {
   const graphName = GRAPH_NAME;
   const graph = state[graphName];
   const currentNode = graph.nodes[item.id];
-  // @ts-ignore  ---> ppaidi-todo: remove ts-ignore
   const newNodeState: GraphNode = {
     ...currentNode,
     ...item,

--- a/libs/plugins/stream-client/src/lib/stream-designer/stream-designer.component.html
+++ b/libs/plugins/stream-client/src/lib/stream-designer/stream-designer.component.html
@@ -66,7 +66,10 @@
       [streamMetadata]="streamState?.metadata"
       (click)="openInputSchemaModal()"
     ></flogo-stream-params-schema-button>
-    <flogo-stream-diagram></flogo-stream-diagram>
+    <flogo-stream-diagram
+      fgAddStage
+      [currentSelection]="currentSelection$ | async"
+    ></flogo-stream-diagram>
     <flogo-stream-stage-configurator></flogo-stream-stage-configurator>
   </ng-template>
 

--- a/libs/plugins/stream-client/src/lib/stream-designer/stream-designer.component.ts
+++ b/libs/plugins/stream-client/src/lib/stream-designer/stream-designer.component.ts
@@ -10,6 +10,7 @@ import { takeUntil, map } from 'rxjs/operators';
 import { ModalService } from '@flogo-web/lib-client/modal';
 import { SingleEmissionSubject, HttpUtilsService } from '@flogo-web/lib-client/core';
 import { ContribInstallerService } from '@flogo-web/lib-client/contrib-installer';
+import { DiagramSelection } from '@flogo-web/lib-client/diagram';
 import { StreamMetadata } from '@flogo-web/plugins/stream-core';
 import {
   ChangeDescription,
@@ -46,6 +47,7 @@ export class StreamDesignerComponent implements OnInit, OnDestroy {
   currentSimulationStage$: Observable<string | number>;
   // todo: add type
   selectedStageInfo$: Observable<any>;
+  currentSelection$: Observable<DiagramSelection>;
   private ngOnDestroy$ = SingleEmissionSubject.create();
 
   constructor(
@@ -59,6 +61,8 @@ export class StreamDesignerComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.simulation.init();
+
+    this.currentSelection$ = this.store.pipe(select(StreamSelectors.getDiagramSelection));
 
     this.store
       .pipe(select(StreamSelectors.selectStreamState))
@@ -76,6 +80,7 @@ export class StreamDesignerComponent implements OnInit, OnDestroy {
       .subscribe(contribDetails =>
         this.store.dispatch(new ContributionInstalled(contribDetails))
       );
+
     this.isSimulatorOpen$ = this.store.pipe(
       select(StreamSelectors.selectSimulatorPanelOpen)
     );

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.html
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.html
@@ -7,39 +7,48 @@
     (mouseenter)="updateDraggingState(draggingPosition.INSIDE, $event.buttons)"
     (mouseleave)="updateDraggingState(draggingPosition.OUTSIDE, $event.buttons)"
   >
-    <flogo-diagram-tile-task
-      *ngFor="let tile of tiles; trackBy: trackTileBy"
-      class="tile__separator"
-      cdkDrag
-      cdkDragBoundary="flogo-stream-diagram"
-      [cdkDragData]="tile?.task?.id"
-      [tile]="tile"
-      [currentSelection]="currentSelection"
-      [icon]="iconIndex[tile?.task?.id]"
-      (select)="selectStage($event)"
-      (remove)="onDiagramAction($event)"
-      (configure)="onDiagramAction($event)"
-      (cdkDragStarted)="onStageDragStart()"
-    >
-      <flogo-diagram-tile-placeholder
-        *cdkDragPlaceholder
-      ></flogo-diagram-tile-placeholder>
-      <ng-template cdkDragPreview [matchSize]="true">
-        <flogo-diagram-tile-preview
-          [id]="tile?.task?.id"
-          [title]="tile?.task?.title"
-          [icon]="iconIndex[tile?.task?.id]"
-        ></flogo-diagram-tile-preview>
-      </ng-template>
-    </flogo-diagram-tile-task>
+    <div class="tile" *ngFor="let tile of tiles; trackBy: trackTileBy">
+      <flogo-diagram-tile-insert
+        *ngIf="hideInsertTile"
+        class="tile__add-between"
+        [tile]="tile"
+        [currentSelection]="currentSelection"
+        (select)="addStage(tile.parentId)"
+        [class.visible-on-hover]="tiles.length"
+        [hidden]="isDragging"
+      ></flogo-diagram-tile-insert>
+      <flogo-diagram-tile-task
+        class="tile__separator"
+        cdkDrag
+        cdkDragBoundary="flogo-stream-diagram"
+        [cdkDragData]="tile?.task?.id"
+        [tile]="tile"
+        [currentSelection]="currentSelection"
+        [icon]="iconIndex[tile?.task?.id]"
+        (select)="selectStage($event)"
+        (remove)="onDiagramAction($event)"
+        (configure)="onDiagramAction($event)"
+        (cdkDragStarted)="onStageDragStart()"
+      >
+        <flogo-diagram-tile-placeholder
+          *cdkDragPlaceholder
+        ></flogo-diagram-tile-placeholder>
+        <ng-template cdkDragPreview [matchSize]="true">
+          <flogo-diagram-tile-preview
+            [id]="tile?.task?.id"
+            [title]="tile?.task?.title"
+            [icon]="iconIndex[tile?.task?.id]"
+          ></flogo-diagram-tile-preview>
+        </ng-template>
+      </flogo-diagram-tile-task>
+    </div>
   </div>
   <flogo-diagram-tile-insert
-    fgAddStage
-    *ngIf="availableSlots > 0"
+    *ngIf="hideInsertTile"
     class="add-button tile__separator"
     [tile]="insertTile"
     [currentSelection]="currentSelection"
-    (select)="addStage()"
+    (select)="addStage(insertTile.parentId)"
     [class.visible-on-hover]="tiles.length"
     [hidden]="isDragging"
   ></flogo-diagram-tile-insert>

--- a/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.less
+++ b/libs/plugins/stream-client/src/lib/stream-diagram/stream-diagram.component.less
@@ -11,6 +11,11 @@
   --add-button-width: 48px;
 }
 
+.tile {
+  display: flex;
+  position: relative;
+}
+
 .tiles-wrapper{
   display: flex;
   padding: 8px;
@@ -25,6 +30,19 @@
     .add-button:before {
       opacity: 0.5;
     }
+  }
+}
+
+.tile__add-between {
+  position: absolute;
+  z-index: 6;
+  height: 18px;
+  width: 18px;
+  margin: 20px 0 0 2px;
+  background-color: #f0f0f0;
+  opacity: 0;
+  &.is-selected {
+    opacity: 1;
   }
 }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

Ability to add a stage in between for streams
 - [x] Show add button in between tiles
 - [x] Restrict add tile in between when the row already has max allowed(10) tiles

Part of #1299 

## How has this been tested?

Tested manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/47237691/86917807-58806300-c143-11ea-9cb7-00e7c4efe95c.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
