### PR TITLE
Flows: debugger panel scrollbar misalignment 

### DIFF
--- a/libs/plugins/flow-client/src/lib/debug-panel/debug-panel.component.less
+++ b/libs/plugins/flow-client/src/lib/debug-panel/debug-panel.component.less
@@ -39,11 +39,11 @@
 
   .activity__field-group {
     width: 50%;
-    padding: 1rem 2rem 1rem 2rem;
+    padding: 16px 20px 16px 20px;
   }
 
   .activity__field-group + .activity__field-group {
-    padding-left: 1rem;
+    padding-left: 55px;
   }
 }
 

--- a/libs/plugins/flow-client/src/lib/debug-panel/debug-panel.component.less
+++ b/libs/plugins/flow-client/src/lib/debug-panel/debug-panel.component.less
@@ -39,7 +39,7 @@
 
   .activity__field-group {
     width: 50%;
-    padding: 16px 20px 16px 20px;
+    padding: 20px;
   }
 
   .activity__field-group + .activity__field-group {
@@ -55,10 +55,10 @@
 
 .activity__info-group {
   width: @info-width;
-  margin-top: 2rem;
+  margin-top: 20px;
   border-right: 1px solid @light-grey;
 
-  padding: 0 1.25rem 1.25rem 1.25rem;
+  padding: 1rem 1.25rem 1.25rem 1.25rem;
 }
 
 .activity__name {

--- a/libs/plugins/flow-client/src/lib/debug-panel/debug-panel.component.less
+++ b/libs/plugins/flow-client/src/lib/debug-panel/debug-panel.component.less
@@ -39,7 +39,7 @@
 
   .activity__field-group {
     width: 50%;
-    padding: 1rem 1rem 1rem 2rem;
+    padding: 1rem 2rem 1rem 2rem;
   }
 
   .activity__field-group + .activity__field-group {

--- a/libs/plugins/flow-client/src/lib/flow.component.html
+++ b/libs/plugins/flow-client/src/lib/flow.component.html
@@ -76,7 +76,7 @@
     <div context-panel-role="primary-area" class="primary-area">
       <ng-container *ngTemplateOutlet="flowContent"></ng-container>
     </div>
-    <div context-panel-role="panel-content" class="panel-content">
+    <div context-panel-role="panel-content">
       <flogo-flow-debug-panel class="debug-panel-container"> </flogo-flow-debug-panel>
     </div>
   </flogo-context-panel-area>

--- a/libs/plugins/flow-client/src/lib/flow.component.less
+++ b/libs/plugins/flow-client/src/lib/flow.component.less
@@ -113,9 +113,6 @@
   display: flex;
 }
 
-.panel-content {
-  padding-left: 1em;
-}
 
 .context-panel-container{
   flex: 1;

--- a/libs/plugins/flow-client/src/lib/flow.component.less
+++ b/libs/plugins/flow-client/src/lib/flow.component.less
@@ -114,7 +114,7 @@
 }
 
 .panel-content {
-  padding: 0 1em;
+  padding-left: 1em;
 }
 
 .context-panel-container{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This solves the issue #1321 "In flow when I select an activity that has both input and outputs and I open the debugger panel the panel content doesn't extend all the way to the right edge of the screen and there's a gap to the left of the scrollbar."

## How has this been tested?
Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
