### PR TITLE
Fixed: Latest log messages are missing when I pop out to a new tab #1291

### DIFF
--- a/apps/server/src/api/ws/engine-log-streamer.ts
+++ b/apps/server/src/api/ws/engine-log-streamer.ts
@@ -5,8 +5,10 @@ import EventEmitter = NodeJS.EventEmitter;
 export class EngineLogStreamer {
   private cleanup: Function;
   private readonly firstConnectionQuery = {
-    limit: 10,
     start: 0,
+    limit: 10,
+    from: 'now',
+    until: '-24hr',
     order: 'desc' as 'desc',
     fields: ['level', 'timestamp', 'message'],
   };
@@ -34,7 +36,7 @@ export class EngineLogStreamer {
       if (err) {
         console.log(err);
       }
-      const docs = results['file'] || [];
+      const docs = results['file'].reverse() || [];
       client.emit('on-connecting', JSON.stringify(docs));
     });
   }

--- a/apps/server/src/api/ws/engine-log-streamer.ts
+++ b/apps/server/src/api/ws/engine-log-streamer.ts
@@ -36,8 +36,8 @@ export class EngineLogStreamer {
       if (err) {
         console.log(err);
       }
-      const docs = results['file'].reverse() || [];
-      client.emit('on-connecting', JSON.stringify(docs));
+      const docs = results['file'] || [];
+      client.emit('on-connecting', JSON.stringify(docs.reverse()));
     });
   }
 

--- a/apps/server/src/api/ws/engine-log-streamer.ts
+++ b/apps/server/src/api/ws/engine-log-streamer.ts
@@ -2,17 +2,15 @@ import * as socketio from 'socket.io';
 import { engineLogger } from '../../common/logging';
 import EventEmitter = NodeJS.EventEmitter;
 
+const CONNECTION_QUERY_PARAMS = {
+  start: 0,
+  limit: 10,
+  until: null,
+  order: 'desc' as 'desc',
+  fields: ['level', 'timestamp', 'message'],
+};
 export class EngineLogStreamer {
   private cleanup: Function;
-  private readonly firstConnectionQuery = {
-    start: 0,
-    limit: 10,
-    from: 'now',
-    until: '-24hr',
-    order: 'desc' as 'desc',
-    fields: ['level', 'timestamp', 'message'],
-  };
-
   constructor(private channel: EventEmitter) {}
 
   init() {
@@ -32,13 +30,16 @@ export class EngineLogStreamer {
   }
 
   onNewConnection(client: socketio.Socket) {
-    engineLogger.query(this.firstConnectionQuery, (err, results) => {
-      if (err) {
-        console.log(err);
+    engineLogger.query(
+      { ...CONNECTION_QUERY_PARAMS, until: new Date() },
+      (err, results) => {
+        if (err) {
+          console.log(err);
+        }
+        const docs = results['file'] || [];
+        client.emit('on-connecting', JSON.stringify(docs.reverse()));
       }
-      const docs = results['file'] || [];
-      client.emit('on-connecting', JSON.stringify(docs.reverse()));
-    });
+    );
   }
 
   destroy() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed the issue where Anand said: "The logs when pop out to a new window does not show all the log messages. When I test run a flow, I can see the latest information again."
The messages are now latest when the logs are popped out to a new window. 

## How has this been tested?
Manually 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
