### PR TITLE
fix: auto stop simulation

### DIFF
--- a/libs/plugins/stream-client/src/lib/core/effects/stream-save.effects.ts
+++ b/libs/plugins/stream-client/src/lib/core/effects/stream-save.effects.ts
@@ -48,7 +48,8 @@ export class StreamSaveEffects {
       StreamActionType.StageItemCreated,
       StreamActionType.DeleteStage,
       StreamActionType.CommitStageConfiguration,
-      StreamActionType.UpdateMetadata
+      StreamActionType.UpdateMetadata,
+      StreamActionType.MoveStage
     ),
     tap(() => {
       this.stopSimulation();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Auto stop stream simulation when stages position changes

## How has this been tested?

Tested manually.

Steps to test:
1) Create an app, add a stream action
2) Add stages(min 2) to the diagram, upload stream input file
3) Click run stream
4) Change the position of the stages by drag and drop to other position
5) Stream simulation should stop

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
