### PR TITLE
fix: disable install button when url input is empty

### DIFF
--- a/libs/lib-client/contrib-installer/src/lib/url-installer/url-installer.component.html
+++ b/libs/lib-client/contrib-installer/src/lib/url-installer/url-installer.component.html
@@ -4,12 +4,18 @@
   placeholder="{{ 'URL-INSTALLER:PASTE-URL' | translate }}"
   [ngModel]="sourceUrl"
   (ngModelChange)="onSourceUrlChange($event)"
+  required
+  #urlInput="ngModel"
 />
 <div class="flogo-installer-url__button-container">
   <button class="flogo-button--secondary" (click)="onCancelAction()">
     {{ 'URL-INSTALLER:CANCEL' | translate }}
   </button>
-  <button class="flogo-button--default" (click)="onInstallAction()">
+  <button
+    class="flogo-button--default"
+    [disabled]="urlInput.invalid"
+    (click)="onInstallAction()"
+  >
     {{ 'MODAL:INSTALL' | translate }}
   </button>
 </div>


### PR DESCRIPTION
## Description

Validate input field of contrib install modal. Disable install button if the input is invalid.

Fixes #823

## How has this been tested?

Tested manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
