### PR TITLE
fix: validate json value correct in mapper

### DIFF
--- a/libs/parser/src/ast/ast-creator.ts
+++ b/libs/parser/src/ast/ast-creator.ts
@@ -226,7 +226,7 @@ export function astCreatorFactory(BaseCstVisitorClass: CstVisitorBase): CstVisit
     array(ctx): JsonNodes.ArrayNode {
       return {
         type: AstNodeType.JsonArray,
-        children: ctx.jsonValue.map(valueNode => this.visit(valueNode)),
+        children: ctx.jsonValue?.map(valueNode => this.visit(valueNode)),
       };
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Mapper input is not validating the JSON value correct, it's treating the empty array([]) value as invalid. As soon as I type empty array as value to any key, input field becomes invalid and the save button grays out.

## How has this been tested?

Manually


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build/CI related changes
- [ ] Documentation related changes
- [ ] Other... Please describe:

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
